### PR TITLE
Optimize Plane

### DIFF
--- a/benchmarks/intersect.cpp
+++ b/benchmarks/intersect.cpp
@@ -78,7 +78,7 @@ static void BM_PlaneIntersect(benchmark::State& state) {
   Diffuse material = Diffuse(new Spectrum(1.0));
   auto plane = Plane(
     &material,
-    new Point3f(0.0, 0.0, 0.0),
+    Point3f(0.0, 0.0, 0.0),
     1
   );
 

--- a/benchmarks/intersect.cpp
+++ b/benchmarks/intersect.cpp
@@ -2,6 +2,7 @@
 #include <benchmark/benchmark.h>
 #include "point3f.h"
 #include "../intersectables/explosion.h"
+#include "../intersectables/plane.h"
 #include "../intersectables/sphere.h"
 #include "../intersectables/triangle.h"
 #include "../materials/diffuse.h"
@@ -72,5 +73,22 @@ static void BM_ExplosionIntersect(benchmark::State& state) {
   }
 }
 BENCHMARK(BM_ExplosionIntersect);
+
+static void BM_PlaneIntersect(benchmark::State& state) {
+  Diffuse material = Diffuse(new Spectrum(1.0));
+  auto plane = Plane(
+    &material,
+    new Point3f(0.0, 0.0, 0.0),
+    1
+  );
+
+  auto rays = MakeRays();
+  for (auto _ : state) {
+    for (auto& r : rays) {
+      std::unique_ptr<HitRecord>(plane.intersect(&r));
+    }
+  }
+}
+BENCHMARK(BM_PlaneIntersect);
 
 }

--- a/include/intersectables/plane.h
+++ b/include/intersectables/plane.h
@@ -18,12 +18,12 @@ class Plane : public Intersectable {
     Material* material;
 
     // normal of the plane
-    Point3f* normal;
+    const Point3f normal;
 
     // distance to origin measured along normal direction
-    float distance;
+    const float distance;
 
-    Plane(Material*, Point3f*, float);
+    Plane(Material*, Point3f, float);
     // plane-ray intersection ray: p(t) = orig + t * dir
     //
     // Implicit plane:

--- a/src/intersectables/plane.cpp
+++ b/src/intersectables/plane.cpp
@@ -2,7 +2,7 @@
 #include <cmath>
 #include "plane.h"
 
-Plane::Plane(Material* material, Point3f* normal, float distance)
+Plane::Plane(Material* material, Point3f normal, float distance)
   : material(material), normal(normal), distance(distance)
 {}
 
@@ -27,14 +27,14 @@ Plane::Plane(Material* material, Point3f* normal, float distance)
  */
 HitRecord* Plane::intersect(Ray* ray) const {
   // incident angle: angle between the ray direction and the plane normal
-  auto cosTheta = normal->dot(ray->direction);
+  auto cosTheta = ray->direction->dot(&normal);
 
   if (std::abs(cosTheta) <= EPSILON) {
     return new HitRecord();
   }
 
   // assumption: point is zero and then we shift by distance
-  float t = -(normal->dot(ray->origin) + distance) / cosTheta;
+  float t = -(ray->origin->dot(&normal) + distance) / cosTheta;
   if (t < 0) {
     return new HitRecord();
   }

--- a/src/scenes/blinnTest.cpp
+++ b/src/scenes/blinnTest.cpp
@@ -34,12 +34,12 @@ void BlinnTest::buildIntersectables() {
   IntersectableList* intersectableList = new IntersectableList();
   Blinn* material = new Blinn(new Spectrum(0.5, 0.5, 0.0), new Spectrum(0.6), 50.0);
   Material* diffuse = new Diffuse(new Spectrum(0.0, 0.5, 0.5));
-  intersectableList->put(new Sphere(material, new Point3f(0.0, 0.0, 0.0), 0.5));
-  intersectableList->put(new Plane(diffuse, new Point3f(1.0, 0.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, new Point3f(-1.0, 0.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, new Point3f(0.0, 1.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, new Point3f(0.0, -1.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, new Point3f(0.0, 0.0, 1.0), 1));
+  intersectableList->put(new Sphere(material, Point3f(0.0, 0.0, 0.0), 0.5));
+  intersectableList->put(new Plane(diffuse, Point3f(1.0, 0.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(-1.0, 0.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(0.0, 1.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(0.0, -1.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(0.0, 0.0, 1.0), 1));
   this->intersectableList = intersectableList;
 }
 

--- a/src/scenes/cameraTest.cpp
+++ b/src/scenes/cameraTest.cpp
@@ -14,10 +14,10 @@ void CameraTest::buildLights() {
 void CameraTest::buildIntersectables() {
   Material* material = new Diffuse(new Spectrum(1.0));
   IntersectableList* intersectableList = new IntersectableList();
-  intersectableList->put(new Plane(material, new Point3f(1.0, 0.0, 0.0), 1));
-  intersectableList->put(new Plane(material, new Point3f(-1.0, 0.0, 0.0), 1));
-  intersectableList->put(new Plane(material, new Point3f(0.0, 1.0, 0.0), 1));
-  intersectableList->put(new Plane(material, new Point3f(0.0, -1.0, 0.0), 1));
-  intersectableList->put(new Plane(material, new Point3f(0.0, 0.0, 1.0), 1));
+  intersectableList->put(new Plane(material, Point3f(1.0, 0.0, 0.0), 1));
+  intersectableList->put(new Plane(material, Point3f(-1.0, 0.0, 0.0), 1));
+  intersectableList->put(new Plane(material, Point3f(0.0, 1.0, 0.0), 1));
+  intersectableList->put(new Plane(material, Point3f(0.0, -1.0, 0.0), 1));
+  intersectableList->put(new Plane(material, Point3f(0.0, 0.0, 1.0), 1));
   this->intersectableList = intersectableList;
 }

--- a/src/scenes/explosionTest.cpp
+++ b/src/scenes/explosionTest.cpp
@@ -20,10 +20,10 @@ void ExplosionTest::buildIntersectables() {
   ExplosionMaterial* material = new ExplosionMaterial(new Spectrum(1.0, 0.0, 0.0), new Spectrum(0.6), 50.0);
   Material* diffuse = new Diffuse(new Spectrum(0.0, 0.5, 0.5));
   intersectableList->put(new Explosion(material, new Point3f(0.0, 0.0, 0.0), 1.0));
-  intersectableList->put(new Plane(diffuse, new Point3f(1.0, 0.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, new Point3f(-1.0, 0.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, new Point3f(0.0, 1.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, new Point3f(0.0, -1.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, new Point3f(0.0, 0.0, 1.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(1.0, 0.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(-1.0, 0.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(0.0, 1.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(0.0, -1.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(0.0, 0.0, 1.0), 1));
   this->intersectableList = intersectableList;
 }

--- a/src/scenes/meshTest.cpp
+++ b/src/scenes/meshTest.cpp
@@ -56,7 +56,7 @@ void MeshTest::buildIntersectables() {
   Mesh* mesh = new Mesh(material, "../meshes/teapot.obj");
   Instance* instance = new Instance(mesh, transform);
   intersectableList->put(instance);
-  intersectableList->put(new Plane(grid, new Point3f(0.0, 0.0, 1.0f), 2.15));
+  intersectableList->put(new Plane(grid, Point3f(0.0, 0.0, 1.0f), 2.15));
   this->intersectableList = intersectableList;
 }
 

--- a/src/scenes/reflectionScene.cpp
+++ b/src/scenes/reflectionScene.cpp
@@ -28,10 +28,10 @@ void ReflectionTest::buildIntersectables() {
   intersectableList->put(new Sphere(blinn, new Point3f(0.0, -0.4, 0.0), 0.5));
   intersectableList->put(new Sphere(blinn2, new Point3f(0.8, 0.5, 0), 0.35));
 
-  intersectableList->put(new Plane(diffuse, new Point3f(-1.0, 0.0, 0.0), 1));
-  intersectableList->put(new Plane(mirror, new Point3f(0.0, 1.0, 0.0), 1));
-  intersectableList->put(new Plane(mirror, new Point3f(0.0, -1.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, new Point3f(0.0, 0.0, 1.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(-1.0, 0.0, 0.0), 1));
+  intersectableList->put(new Plane(mirror, Point3f(0.0, 1.0, 0.0), 1));
+  intersectableList->put(new Plane(mirror, Point3f(0.0, -1.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Point3f(0.0, 0.0, 1.0), 1));
   this->intersectableList = intersectableList;
 }
 

--- a/src/scenes/refractiveScene.cpp
+++ b/src/scenes/refractiveScene.cpp
@@ -52,7 +52,7 @@ void RefractiveTest::buildIntersectables() {
   );
 
   intersectableList->put(new Sphere(material, new Point3f(0.0, 0.0, 0.0), 1.0));
-  intersectableList->put(new Plane(grid, new Point3f(0.0, 0.0, 1.0f), 2.15));
+  intersectableList->put(new Plane(grid, Point3f(0.0, 0.0, 1.0f), 2.15));
 
   this->intersectableList = intersectableList;
 }


### PR DESCRIPTION
This patch optimizes and refactors the plane class.

According to the benchmark, I could improve the performance from `470ns` to `450ns` on my machine.

I still could successfully re-render all demo-scenes.