### PR TITLE
Reduce leakage and improve performance of explosion intersections.

### DIFF
--- a/benchmarks/intersect.cpp
+++ b/benchmarks/intersect.cpp
@@ -1,6 +1,7 @@
 #include <memory>
 #include <benchmark/benchmark.h>
 #include "point3f.h"
+#include "../intersectables/explosion.h"
 #include "../intersectables/sphere.h"
 #include "../intersectables/triangle.h"
 #include "../materials/diffuse.h"
@@ -54,5 +55,22 @@ static void BM_SphereIntersect(benchmark::State& state) {
 }
 BENCHMARK(BM_SphereIntersect);
 
+static void BM_ExplosionIntersect(benchmark::State& state) {
+  Diffuse material = Diffuse(new Spectrum(1.0));
+  auto explosion = Explosion(
+    &material,
+    Point3f(0.0, 0.0, 0.0),
+    1
+  );
+
+  auto rays = MakeRays();
+
+  for (auto _ : state) {
+    for (auto& r : rays) {
+        std::unique_ptr<HitRecord>(explosion.intersect(&r));
+    }
+  }
+}
+BENCHMARK(BM_ExplosionIntersect);
 
 }

--- a/include/intersectables/explosion.h
+++ b/include/intersectables/explosion.h
@@ -17,10 +17,10 @@ class Explosion : public Intersectable {
     Explosion(Material*, const Point3f, float);
 
     virtual HitRecord* intersect(Ray* ray) const;
-    float signed_distance(Point3f* p) const;
-    float fractal_brownian_motion(Point3f* x) const;
-    Point3f rotate(Point3f* v) const;
-    float noise(Point3f* x) const;
+    float signed_distance(const Point3f& p) const;
+    float fractal_brownian_motion(const Point3f& x) const;
+    Point3f rotate(const Point3f& v) const;
+    float noise(const Point3f& x) const;
 
     template <typename T> inline T lerp(const T &v0, const T &v1, float t) const {
       return v0 + (v1-v0)*std::max(0.f, std::min(1.f, t));

--- a/include/intersectables/explosion.h
+++ b/include/intersectables/explosion.h
@@ -11,10 +11,10 @@ class Material;
 class Explosion : public Intersectable {
   public:
     Material* material;
-    Point3f* center;
-    float radius;
+    const Point3f center;
+    const float radius;
 
-    Explosion(Material*, Point3f*, float);
+    Explosion(Material*, const Point3f, float);
 
     virtual HitRecord* intersect(Ray* ray) const;
     float signed_distance(Point3f* p) const;

--- a/include/math/point3f.h
+++ b/include/math/point3f.h
@@ -44,11 +44,11 @@ class Point3f {
     /**
      * @return l2-dot product of this point's coordinates.
      */
-    float dot();
+    float dot() const;
 
-    float dot(const Point3f* other);
+    float dot(const Point3f* other) const;
 
-    float norm();
+    float norm() const;
 
     // Make length of this vector equal 1 (in l2 norm's sense) but preserve its
     // direction.

--- a/src/intersectables/explosion.cpp
+++ b/src/intersectables/explosion.cpp
@@ -7,49 +7,48 @@ Explosion::Explosion(Material* material, const Point3f center, float radius)
 {}
 
 HitRecord* Explosion::intersect(Ray* ray) const {
-  Point3f* orig = new Point3f(ray->origin);
-  Point3f* dir = new Point3f(ray->direction);
-  if (orig->dot() - pow(orig->dot(dir), 2) > pow(radius, 2)) {
+  const Point3f& orig = *ray->origin;
+  const Point3f& dir = *ray->direction;
+  if (orig.dot() - pow(orig.dot(&dir), 2) > pow(radius, 2)) {
     return new HitRecord();
   }
 
-  Point3f* hitPos = new Point3f(orig);
+  Point3f hitPos = orig;
   for (size_t i = 0; i < 128; i++) {
     float d = signed_distance(hitPos);
-    Point3f* wIn = new Point3f(ray->direction);
-    wIn->negate();
-    wIn->normalize();
+    if (d >= 0) {
+      Point3f dcopy = dir;
+      dcopy.scale(std::max(d * 0.1f, .01f));
+      hitPos.add(&dcopy);
+      continue;
+    }
 
     const float eps = 0.1;
 
-    Point3f* dx = new Point3f(eps, 0, 0);
-    dx->add(hitPos);
+    Point3f dx = Point3f(eps, 0, 0);
+    dx.add(&hitPos);
 
-    Point3f* dy = new Point3f(0, eps, 0);
-    dy->add(hitPos);
+    Point3f dy = Point3f(0, eps, 0);
+    dy.add(&hitPos);
 
-    Point3f* dz = new Point3f(0, 0, eps);
-    dz->add(hitPos);
+    Point3f dz = Point3f(0, 0, eps);
+    dz.add(&hitPos);
 
     float nx = signed_distance(dx) - d;
     float ny = signed_distance(dy) - d;
     float nz = signed_distance(dz) - d;
 
-    delete dx;
-    delete dy;
-    delete dz;
-
-    Point3f* norm = new Point3f(nx, ny, nz);
-    norm->normalize();
-
-    // compute parameter t, given a intersction point with a ray
-    float t = (hitPos->x - ray->origin->x) / ray->direction->x;
     if (d < 0) {
-      delete dir;
-      delete orig;
+      // compute parameter t, given a intersction point with a ray
+      float t = (hitPos.x - ray->origin->x) / ray->direction->x;
+      Point3f* norm = new Point3f(nx, ny, nz);
+      norm->normalize();
+      Point3f* wIn = new Point3f(ray->direction);
+      wIn->negate();
+      wIn->normalize();
       return new HitRecord (
         t,
-        hitPos,
+        new Point3f(hitPos),
         norm,
         new Point3f(),
         wIn,
@@ -57,66 +56,56 @@ HitRecord* Explosion::intersect(Ray* ray) const {
         this
       );
     }
-    Point3f* dcopy = new Point3f(dir);
-    dcopy->scale(std::max(d * 0.1f, .01f));
-    hitPos->add(dcopy);
-    delete dcopy;
-    delete wIn;
   }
   return new HitRecord();
 }
 
-float Explosion::signed_distance(Point3f* p) const { // this function defines the implicit surface we render
+float Explosion::signed_distance(const Point3f& p) const { // this function defines the implicit surface we render
   Point3f q(p);
   q.scale(3.4);
   float noise_amplitude = 1.0;
   float displacement = -fractal_brownian_motion(&q) * noise_amplitude;
-  return p->norm() - (radius + displacement);
+  return p.norm() - (radius + displacement);
 }
 
-Point3f Explosion::rotate(Point3f* v) const {
+Point3f Explosion::rotate(const Point3f& v) const {
   Point3f p(
-    Point3f(0.00,  0.80,  0.60).dot(v),
-    Point3f(-0.80,  0.36, -0.48).dot(v),
-    Point3f(-0.60, -0.48,  0.64).dot(v)
+    Point3f(0.00,  0.80,  0.60).dot(&v),
+    Point3f(-0.80,  0.36, -0.48).dot(&v),
+    Point3f(-0.60, -0.48,  0.64).dot(&v)
   );
   return p;
 }
 
-float Explosion::noise(Point3f* x) const {
-  Point3f* p = new Point3f(floor(x->x), floor(x->y), floor(x->z));
-  Point3f* f = new Point3f(x->x - p->x, x->y - p->y, x->z - p->z);
+float Explosion::noise(const Point3f& x) const {
+  Point3f p = Point3f(floor(x.x), floor(x.y), floor(x.z));
+  Point3f f = Point3f(x.x - p.x, x.y - p.y, x.z - p.z);
 
-  Point3f* ff = new Point3f(f);
-  ff->scale(2);
+  Point3f ff = Point3f(f);
+  ff.scale(2);
 
-  Point3f* fff = new Point3f(3.f, 3.f, 3.f);
-  fff->sub(ff);
+  Point3f fff = Point3f(3.f, 3.f, 3.f);
+  fff.sub(&ff);
 
-  Point3f* ffff = new Point3f(f->x * fff->x, f->y * fff->y, f->z * fff->z);
-  Point3f f5(f->x * ffff->x, f->y * ffff->y, f->z * ffff->z);
-  delete f;
-  delete ff;
-  delete fff;
-  delete ffff;
+  Point3f ffff = new Point3f(f.x * fff.x, f.y * fff.y, f.z * fff.z);
+  Point3f f5(f.x * ffff.x, f.y * ffff.y, f.z * ffff.z);
 
-  f = &f5;
   Point3f tmp(1.f, 57.f, 113.f);
-  float n = p->dot(&tmp);
+  float n = p.dot(&tmp);
   return lerp(lerp(
-        lerp(hash(n +  0.f), hash(n +  1.f), f->x),
-        lerp(hash(n + 57.f), hash(n + 58.f), f->x), f->y),
+        lerp(hash(n +  0.f), hash(n +  1.f), f5.x),
+        lerp(hash(n + 57.f), hash(n + 58.f), f5.x), f5.y),
       lerp(
-        lerp(hash(n + 113.f), hash(n + 114.f), f->x),
-        lerp(hash(n + 170.f), hash(n + 171.f), f->x), f->y), f->z);
+        lerp(hash(n + 113.f), hash(n + 114.f), f5.x),
+        lerp(hash(n + 170.f), hash(n + 171.f), f5.x), f5.y), f5.z);
 }
 
-float Explosion::fractal_brownian_motion(Point3f* x) const {
+float Explosion::fractal_brownian_motion(const Point3f& x) const {
     Point3f p = rotate(x);
     float f = 0;
-    f += 0.5000 * noise(&p); p.scale(2.32);
-    f += 0.2500 * noise(&p); p.scale(3.03);
-    f += 0.1250 * noise(&p); p.scale(2.61);
-    f += 0.0625 * noise(&p);
+    f += 0.5000 * noise(p); p.scale(2.32);
+    f += 0.2500 * noise(p); p.scale(3.03);
+    f += 0.1250 * noise(p); p.scale(2.61);
+    f += 0.0625 * noise(p);
     return f / 0.9375;
 }

--- a/src/intersectables/explosion.cpp
+++ b/src/intersectables/explosion.cpp
@@ -2,7 +2,7 @@
 #include <cmath>
 #include "explosion.h"
 
-Explosion::Explosion(Material* material, Point3f* center, float radius)
+Explosion::Explosion(Material* material, const Point3f center, float radius)
   : material(material), center(center), radius(radius)
 {}
 

--- a/src/math/point3f.cpp
+++ b/src/math/point3f.cpp
@@ -57,7 +57,7 @@ Point3f* Point3f::cross(const Point3f* other) {
   return new Point3f(cx, cy, cz);
 }
 
-float Point3f::norm() {
+float Point3f::norm() const {
   return sqrt(this->dot());
 }
 
@@ -67,11 +67,11 @@ void Point3f::normalize() {
   this->scale(1.0 / scale);
 }
 
-float Point3f::dot() {
+float Point3f::dot() const {
   return x * x + y * y + z * z;
 }
 
-float Point3f::dot(const Point3f* other) {
+float Point3f::dot(const Point3f* other) const {
   return x * other->x + y * other->y + z * other->z;
 }
 


### PR DESCRIPTION
Again by making more use of stack variables. Allocating to heap is expensive. Timings:

Before:
BM_ExplosionIntersect    1742571 ns      1741476 ns          400

After:
BM_ExplosionIntersect     284027 ns       283994 ns         2452