### PR TITLE
Adding benchmark to integrator and fixing memory leak.

### DIFF
--- a/benchmarks/integrate.cpp
+++ b/benchmarks/integrate.cpp
@@ -1,0 +1,35 @@
+#include <benchmark/benchmark.h>
+#include "integrators/whittedIntegrator.h"
+#include "intersectables/sphere.h"
+#include "materials/diffuse.h"
+
+namespace {
+std::vector<Ray> MakeRays() {
+  return {
+      Ray(new Vector3f(1.0, 1.0, 1.0), new Vector3f(-1, -1, -1)),
+      Ray(new Vector3f(-1.0, -1.0, -1.0), new Vector3f(1, 1, 1)),
+      Ray(new Vector3f(0.5, 0.5, 1.0), new Vector3f(0, 0, -1)),
+      Ray(new Vector3f(0.5, 0.5, -1.0), new Vector3f(0, 0, 1)),
+  };
+}
+
+static void BM_WhittedIntegrator(benchmark::State& state) {
+  Material* diffuse = new Diffuse(new Spectrum(0.0, 0.5, 0.5));
+  IntersectableList* intersectableList = new IntersectableList();
+  intersectableList->put(new Sphere(diffuse, Vector3f(0.0, 0.0, 0.0), 0.5));
+
+  std::vector<PointLight*>* lightList = new std::vector<PointLight*>;
+  lightList->push_back(new PointLight(Vector3f(0.5, 0.5, 2.0), new Spectrum(1.0)));
+
+  auto integrator = WhittedIntegrator(intersectableList, lightList);
+
+  auto rays = MakeRays();
+
+  for (auto _ : state) {
+    for (auto& r : rays) {
+      integrator.integrate(r);
+    }
+  }
+}
+BENCHMARK(BM_WhittedIntegrator);
+}  // namespace

--- a/include/integrators/whittedIntegrator.h
+++ b/include/integrators/whittedIntegrator.h
@@ -8,7 +8,8 @@
 
 class WhittedIntegrator : public Integrator {
  private:
-  Scene* scene;
+  const IntersectableList* intersectableList;
+  const std::vector<PointLight*>* lights;
 
   // Check whether hitPosition receives light
   //
@@ -16,7 +17,7 @@ class WhittedIntegrator : public Integrator {
   // @param L light direction vector
   // @param t parameter of ray equation p_uvw(t) = 0 + t(s_uvw-0)
   // @return is light source occluded by object at hitPostion?
-  bool isOccluded(Vector3f* hitPosition, Vector3f* lightDir, float eps);
+  bool isOccluded(Vector3f* hitPosition, Vector3f* lightDir, float eps) const;
 
   // Compute BRDF contribution for a given source at closest intersection point.
   //
@@ -24,10 +25,11 @@ class WhittedIntegrator : public Integrator {
   // @param hitRecord closest intersection primary ray with scene.
   // @param t parameter of ray equation p_uvw(t) = 0 + t(s_uvw-0).
   // @return returns current spectrum of light source at intersaction point.
-  Spectrum* contributionOf(PointLight* lightSource, HitRecord* hitRecord);
+  Spectrum* contributionOf(const PointLight* lightSource, HitRecord* hitRecord) const;
 
  public:
-  WhittedIntegrator(Scene*);
+  WhittedIntegrator(const IntersectableList* intersectableList,
+                    const std::vector<PointLight*>* lights);
   Spectrum* integrate(const Ray&);
 };
 #endif

--- a/src/integrators/whittedIntegrator.cpp
+++ b/src/integrators/whittedIntegrator.cpp
@@ -69,12 +69,8 @@ WhittedIntegrator::WhittedIntegrator(const IntersectableList* intersectableList,
 Spectrum* WhittedIntegrator::integrate(const Ray& ray) {
   int MAX_DEPTH = 5;
 
-  HitRecord* hitRecord = intersectableList->intersect(ray);
+  auto hitRecord = std::unique_ptr<HitRecord>(intersectableList->intersect(ray));
   if (!hitRecord->isValid()) {
-    // only delete hitRecord for deepest hit record
-    if (ray.depth == MAX_DEPTH) {
-      delete hitRecord;
-    }
     return new Spectrum();
   }
 
@@ -82,7 +78,8 @@ Spectrum* WhittedIntegrator::integrate(const Ray& ray) {
   Spectrum refraction;
 
   if (hitRecord->material->hasSpecularReflection() && ray.depth < MAX_DEPTH) {
-    ShadingSample* sample = hitRecord->material->evaluateSpecularReflection(hitRecord);
+    auto sample = std::unique_ptr<ShadingSample>(
+        hitRecord->material->evaluateSpecularReflection(hitRecord.get()));
     if (sample->isValid) {
       reflection.add(*sample->brdf);
       Ray reflectedRay(new Vector3f(*hitRecord->position), sample->w, ray.depth + 1);
@@ -91,11 +88,11 @@ Spectrum* WhittedIntegrator::integrate(const Ray& ray) {
       delete reflectedRay.origin;
       delete spec;
     }
-    delete sample;
   }
 
   if (hitRecord->material->hasSpecularRefraction() && ray.depth < MAX_DEPTH) {
-    ShadingSample* sample = hitRecord->material->evaluateSpecularRefraction(hitRecord);
+    auto sample = std::unique_ptr<ShadingSample>(
+        hitRecord->material->evaluateSpecularRefraction(hitRecord.get()));
     if (sample->isValid) {
       refraction.add(*sample->brdf);
 
@@ -104,7 +101,6 @@ Spectrum* WhittedIntegrator::integrate(const Ray& ray) {
       refraction.mult(*spec);
 
       delete refractedRay.origin;
-      delete sample;
       delete spec;
     }
   }
@@ -120,11 +116,10 @@ Spectrum* WhittedIntegrator::integrate(const Ray& ray) {
 
   Spectrum* contribution = new Spectrum();
   for (const PointLight* lightSource : *lights) {
-    Spectrum* currentContribution = contributionOf(lightSource, hitRecord);
+    Spectrum* currentContribution = contributionOf(lightSource, hitRecord.get());
     contribution->add(*currentContribution);
     delete currentContribution;
   }
-  delete hitRecord;
 
   return contribution;
 }

--- a/src/scenes/blinnTest.cpp
+++ b/src/scenes/blinnTest.cpp
@@ -42,5 +42,5 @@ void BlinnTest::buildIntersectables() {
 
 void BlinnTest::buildIntegrator() {
   // this->integrator = new DebugIntegrator(this);
-  this->integrator = new WhittedIntegrator(this);
+  this->integrator = new WhittedIntegrator(this->intersectableList, this->lightList);
 }

--- a/src/scenes/meshTest.cpp
+++ b/src/scenes/meshTest.cpp
@@ -48,6 +48,8 @@ void MeshTest::buildIntersectables() {
   this->intersectableList = intersectableList;
 }
 
-void MeshTest::buildIntegrator() { this->integrator = new WhittedIntegrator(this); }
+void MeshTest::buildIntegrator() {
+  this->integrator = new WhittedIntegrator(this->intersectableList, this->lightList);
+}
 
 void MeshTest::buildSampler() { this->sampler = new RandomSampler(); }

--- a/src/scenes/reflectionScene.cpp
+++ b/src/scenes/reflectionScene.cpp
@@ -34,7 +34,9 @@ void ReflectionTest::buildIntersectables() {
   this->intersectableList = intersectableList;
 }
 
-void ReflectionTest::buildIntegrator() { this->integrator = new WhittedIntegrator(this); }
+void ReflectionTest::buildIntegrator() {
+  this->integrator = new WhittedIntegrator(this->intersectableList, this->lightList);
+}
 
 void ReflectionTest::buildSampler() {
   this->sampler = new RandomSampler();

--- a/src/scenes/refractiveScene.cpp
+++ b/src/scenes/refractiveScene.cpp
@@ -51,7 +51,7 @@ void RefractiveTest::buildIntersectables() {
 
 void RefractiveTest::buildIntegrator() {
   // this->integrator = new DebugIntegrator(this);
-  this->integrator = new WhittedIntegrator(this);
+  this->integrator = new WhittedIntegrator(this->intersectableList, this->lightList);
 }
 
 void RefractiveTest::buildSampler() { this->sampler = new RandomSampler(); }

--- a/src/scenes/scene.cpp
+++ b/src/scenes/scene.cpp
@@ -41,6 +41,8 @@ void Scene::buildIntersectables() {
   std::cout << "Scene#buildIntersectables not implemented yet." << std::endl;
 }
 
-void Scene::buildIntegrator() { this->integrator = new WhittedIntegrator(this); }
+void Scene::buildIntegrator() {
+  this->integrator = new WhittedIntegrator(this->intersectableList, this->lightList);
+}
 
 void Scene::buildSampler() { this->sampler = new OneSampler(); }


### PR DESCRIPTION
Hitrecord was previously escaping deletion in certain paths. Performance is not impacted from the additional delete calls.