### PR TITLE
Letting ShaddingSample own it's members.

### DIFF
--- a/include/materials/blinn.h
+++ b/include/materials/blinn.h
@@ -17,7 +17,7 @@ class Blinn : public Material {
   virtual bool hasSpecularReflection();
   virtual bool hasSpecularRefraction();
   virtual bool castsShadows();
-  virtual ShadingSample* evaluateSpecularReflection(HitRecord* hitRecord);
-  virtual ShadingSample* evaluateSpecularRefraction(HitRecord* hitRecord);
+  ShadingSample evaluateSpecularReflection(HitRecord* hitRecord) const override;
+  ShadingSample evaluateSpecularRefraction(HitRecord* hitRecord) const override;
 };
 #endif

--- a/include/materials/diffuse.h
+++ b/include/materials/diffuse.h
@@ -18,7 +18,7 @@ class Diffuse : public Material {
   virtual bool hasSpecularReflection();
   virtual bool hasSpecularRefraction();
   virtual bool castsShadows();
-  virtual ShadingSample* evaluateSpecularReflection(HitRecord* hitRecord);
-  virtual ShadingSample* evaluateSpecularRefraction(HitRecord* hitRecord);
+  ShadingSample evaluateSpecularReflection(HitRecord* hitRecord) const override;
+  ShadingSample evaluateSpecularRefraction(HitRecord* hitRecord) const override;
 };
 #endif

--- a/include/materials/explosionMaterial.h
+++ b/include/materials/explosionMaterial.h
@@ -31,7 +31,7 @@ class ExplosionMaterial : public Material {
   virtual bool hasSpecularRefraction();
   virtual bool castsShadows();
 
-  virtual ShadingSample* evaluateSpecularReflection(HitRecord* hitRecord);
-  virtual ShadingSample* evaluateSpecularRefraction(HitRecord* hitRecord);
+  ShadingSample evaluateSpecularReflection(HitRecord* hitRecord) const override;
+  ShadingSample evaluateSpecularRefraction(HitRecord* hitRecord) const override;
 };
 #endif

--- a/include/materials/gridTexturedMaterial.h
+++ b/include/materials/gridTexturedMaterial.h
@@ -26,7 +26,7 @@ class GridTexturedMaterial : public Material {
   virtual bool hasSpecularRefraction();
   virtual bool castsShadows();
 
-  virtual ShadingSample* evaluateSpecularReflection(HitRecord* hitRecord);
-  virtual ShadingSample* evaluateSpecularRefraction(HitRecord* hitRecord);
+  ShadingSample evaluateSpecularReflection(HitRecord* hitRecord) const override;
+  ShadingSample evaluateSpecularRefraction(HitRecord* hitRecord) const override;
 };
 #endif

--- a/include/materials/material.h
+++ b/include/materials/material.h
@@ -57,12 +57,12 @@ class Material {
    * Evaluate specular reflection. This method is typically called by a recursive
    * ray tracer to follow the path of specular reflection.
    */
-  virtual ShadingSample* evaluateSpecularReflection(HitRecord* hitRecord) = 0;
+  virtual ShadingSample evaluateSpecularReflection(HitRecord* hitRecord) const = 0;
 
   /**
    * Evaluate specular refraction. This method is typically called by a
    * recursive ray tracer to follow the path of specular refraction.
    */
-  virtual ShadingSample* evaluateSpecularRefraction(HitRecord* hitRecord) = 0;
+  virtual ShadingSample evaluateSpecularRefraction(HitRecord* hitRecord) const = 0;
 };
 #endif

--- a/include/materials/pointLightMaterial.h
+++ b/include/materials/pointLightMaterial.h
@@ -6,7 +6,7 @@
 #include "../spectrum.h"
 #include "material.h"
 
-class PointLightMaterial {
+class PointLightMaterial : public Material {
  private:
   const Spectrum emission;
 
@@ -18,7 +18,7 @@ class PointLightMaterial {
   virtual bool hasSpecularReflection();
   virtual bool hasSpecularRefraction();
   virtual bool castsShadows();
-  virtual ShadingSample* evaluateSpecularReflection(HitRecord* hitRecord);
-  virtual ShadingSample* evaluateSpecularRefraction(HitRecord* hitRecord);
+  ShadingSample evaluateSpecularReflection(HitRecord* hitRecord) const override;
+  ShadingSample evaluateSpecularRefraction(HitRecord* hitRecord) const override;
 };
 #endif

--- a/include/materials/reflectiveMaterial.h
+++ b/include/materials/reflectiveMaterial.h
@@ -22,7 +22,7 @@ class ReflectiveMaterial : public Material {
   virtual bool hasSpecularRefraction();
   virtual bool castsShadows();
 
-  virtual ShadingSample* evaluateSpecularReflection(HitRecord* hitRecord);
-  virtual ShadingSample* evaluateSpecularRefraction(HitRecord* hitRecord);
+  ShadingSample evaluateSpecularReflection(HitRecord* hitRecord) const override;
+  ShadingSample evaluateSpecularRefraction(HitRecord* hitRecord) const override;
 };
 #endif

--- a/include/materials/refractiveMaterial.h
+++ b/include/materials/refractiveMaterial.h
@@ -27,7 +27,7 @@ class RefractiveMaterial : public Material {
   virtual bool hasSpecularRefraction();
   virtual bool castsShadows();
 
-  virtual ShadingSample* evaluateSpecularReflection(HitRecord* hitRecord);
-  virtual ShadingSample* evaluateSpecularRefraction(HitRecord* hitRecord);
+  ShadingSample evaluateSpecularReflection(HitRecord* hitRecord) const override;
+  ShadingSample evaluateSpecularRefraction(HitRecord* hitRecord) const override;
 };
 #endif

--- a/include/shadingSample.h
+++ b/include/shadingSample.h
@@ -6,27 +6,26 @@
 
 class ShadingSample {
  public:
-  Spectrum* brdf;
-  Spectrum* emission;
+  const Spectrum brdf;
+  const Spectrum emission;
 
   // sample direction
-  Vector3f* w;
+  const Vector3f w;
 
   /**
    * Tells the integrator whether this is a specular sample. In this case, a
    * cosine factor in the specular BRDF should be omitted in the returned
    * BRDF value, and the integrator should act accordingly.
    */
-  bool isSpecular;
-  bool isValid;
+  const bool isSpecular;
+  const bool isValid;
 
   /**
    * The (directional) probability density of the sample
    */
-  float p;
+  const float p;
 
-  ~ShadingSample();
-  ShadingSample(Spectrum*, Spectrum*, Vector3f*, bool, float);
+  ShadingSample(Spectrum, Spectrum, Vector3f, bool, float);
   ShadingSample();
 };
 #endif

--- a/src/integrators/whittedIntegrator.cpp
+++ b/src/integrators/whittedIntegrator.cpp
@@ -79,29 +79,28 @@ Spectrum* WhittedIntegrator::integrate(const Ray& ray) {
   Spectrum refraction;
 
   if (hitRecord->material->hasSpecularReflection() && ray.depth < MAX_DEPTH) {
-    ShadingSample* sample = hitRecord->material->evaluateSpecularReflection(hitRecord);
-    if (sample->isValid) {
-      reflection.add(*sample->brdf);
-      Ray reflectedRay(new Vector3f(*hitRecord->position), sample->w, ray.depth + 1);
+    ShadingSample sample = hitRecord->material->evaluateSpecularReflection(hitRecord);
+    if (sample.isValid) {
+      reflection.add(sample.brdf);
+      Ray reflectedRay(new Vector3f(*hitRecord->position), new Vector3f(sample.w), ray.depth + 1);
       Spectrum* spec = integrate(reflectedRay);
       reflection.mult(*spec);
       delete reflectedRay.origin;
       delete spec;
     }
-    delete sample;
   }
 
   if (hitRecord->material->hasSpecularRefraction() && ray.depth < MAX_DEPTH) {
-    ShadingSample* sample = hitRecord->material->evaluateSpecularRefraction(hitRecord);
-    if (sample->isValid) {
-      refraction.add(*sample->brdf);
+    ShadingSample sample = hitRecord->material->evaluateSpecularRefraction(hitRecord);
+    if (sample.isValid) {
+      refraction.add(sample.brdf);
 
-      const Ray refractedRay(new Vector3f(*hitRecord->position), sample->w, ray.depth + 1);
+      const Ray refractedRay(new Vector3f(*hitRecord->position), new Vector3f(sample.w),
+                             ray.depth + 1);
       Spectrum* spec = integrate(refractedRay);
       refraction.mult(*spec);
 
       delete refractedRay.origin;
-      delete sample;
       delete spec;
     }
   }

--- a/src/materials/blinn.cpp
+++ b/src/materials/blinn.cpp
@@ -35,10 +35,6 @@ bool Blinn::hasSpecularRefraction() { return false; }
 
 bool Blinn::castsShadows() { return true; }
 
-ShadingSample* Blinn::evaluateSpecularReflection(HitRecord*) {
-  return new ShadingSample();
-}
+ShadingSample Blinn::evaluateSpecularReflection(HitRecord*) const { return ShadingSample(); }
 
-ShadingSample* Blinn::evaluateSpecularRefraction(HitRecord*) {
-  return new ShadingSample();
-}
+ShadingSample Blinn::evaluateSpecularRefraction(HitRecord*) const { return ShadingSample(); }

--- a/src/materials/diffuse.cpp
+++ b/src/materials/diffuse.cpp
@@ -16,10 +16,10 @@ bool Diffuse::hasSpecularRefraction() { return false; }
 
 bool Diffuse::castsShadows() { return true; }
 
-ShadingSample* Diffuse::evaluateSpecularReflection(HitRecord* hitRecord) {
-  return new ShadingSample();
+ShadingSample Diffuse::evaluateSpecularReflection(HitRecord* hitRecord) const {
+  return ShadingSample();
 }
 
-ShadingSample* Diffuse::evaluateSpecularRefraction(HitRecord* hitRecord) {
-  return new ShadingSample();
+ShadingSample Diffuse::evaluateSpecularRefraction(HitRecord* hitRecord) const {
+  return ShadingSample();
 }

--- a/src/materials/explosionMaterial.cpp
+++ b/src/materials/explosionMaterial.cpp
@@ -54,10 +54,10 @@ bool ExplosionMaterial::hasSpecularRefraction() { return false; }
 
 bool ExplosionMaterial::castsShadows() { return true; }
 
-ShadingSample* ExplosionMaterial::evaluateSpecularReflection(HitRecord*) {
-  return new ShadingSample();
+ShadingSample ExplosionMaterial::evaluateSpecularReflection(HitRecord*) const {
+  return ShadingSample();
 }
 
-ShadingSample* ExplosionMaterial::evaluateSpecularRefraction(HitRecord*) {
-  return new ShadingSample();
+ShadingSample ExplosionMaterial::evaluateSpecularRefraction(HitRecord*) const {
+  return ShadingSample();
 }

--- a/src/materials/gridTexturedMaterial.cpp
+++ b/src/materials/gridTexturedMaterial.cpp
@@ -49,10 +49,10 @@ bool GridTexturedMaterial::hasSpecularRefraction() { return diffuse.hasSpecularR
 
 bool GridTexturedMaterial::castsShadows() { return diffuse.castsShadows(); }
 
-ShadingSample* GridTexturedMaterial::evaluateSpecularReflection(HitRecord* hitRecord) {
+ShadingSample GridTexturedMaterial::evaluateSpecularReflection(HitRecord* hitRecord) const {
   return diffuse.evaluateSpecularReflection(hitRecord);
 }
 
-ShadingSample* GridTexturedMaterial::evaluateSpecularRefraction(HitRecord* hitRecord) {
+ShadingSample GridTexturedMaterial::evaluateSpecularRefraction(HitRecord* hitRecord) const {
   return diffuse.evaluateSpecularRefraction(hitRecord);
 }

--- a/src/materials/pointLightMaterial.cpp
+++ b/src/materials/pointLightMaterial.cpp
@@ -17,10 +17,10 @@ bool PointLightMaterial::hasSpecularRefraction() { return false; }
 
 bool PointLightMaterial::castsShadows() { return false; }
 
-ShadingSample* PointLightMaterial::evaluateSpecularReflection(HitRecord* hitRecord) {
-  return new ShadingSample();
+ShadingSample PointLightMaterial::evaluateSpecularReflection(HitRecord* hitRecord) const {
+  return ShadingSample();
 }
 
-ShadingSample* PointLightMaterial::evaluateSpecularRefraction(HitRecord* hitRecord) {
-  return new ShadingSample();
+ShadingSample PointLightMaterial::evaluateSpecularRefraction(HitRecord* hitRecord) const {
+  return ShadingSample();
 }

--- a/src/materials/reflectiveMaterial.cpp
+++ b/src/materials/reflectiveMaterial.cpp
@@ -17,13 +17,11 @@ bool ReflectiveMaterial::hasSpecularRefraction() { return false; }
 
 bool ReflectiveMaterial::castsShadows() { return true; }
 
-ShadingSample* ReflectiveMaterial::evaluateSpecularReflection(HitRecord* hitRecord) {
+ShadingSample ReflectiveMaterial::evaluateSpecularReflection(HitRecord* hitRecord) const {
   auto reflectedDir = hitRecord->wIn->invReflected(*hitRecord->normal);
-  ShadingSample* sample =
-      new ShadingSample(new Spectrum(ks), new Spectrum(), reflectedDir, true, 1);
-  return sample;
+  return ShadingSample(Spectrum(ks), Spectrum(), *reflectedDir, true, 1);
 }
 
-ShadingSample* ReflectiveMaterial::evaluateSpecularRefraction(HitRecord* hitRecord) {
-  return new ShadingSample();
+ShadingSample ReflectiveMaterial::evaluateSpecularRefraction(HitRecord* hitRecord) const {
+  return ShadingSample();
 }

--- a/src/shadingSample.cpp
+++ b/src/shadingSample.cpp
@@ -1,13 +1,7 @@
 #include "shadingSample.h"
 
-ShadingSample::~ShadingSample() {
-  delete brdf;
-  delete emission;
-  delete w;
-}
-
-ShadingSample::ShadingSample(Spectrum* brdf, Spectrum* emission, Vector3f* w, bool isSpecular,
-                             float p)
+ShadingSample::ShadingSample(const Spectrum brdf, const Spectrum emission, const Vector3f w,
+                             bool isSpecular, float p)
     : brdf(brdf), emission(emission), w(w), isSpecular(isSpecular), isValid(true), p(p) {}
 
-ShadingSample::ShadingSample() : isValid(false) {}
+ShadingSample::ShadingSample() : isSpecular(false), isValid(false), p(0) {}


### PR DESCRIPTION
Further adapting interface that return shading samples to return copy
instead of pointer (to clearify ownership relation).

Also moving to use 'override' keyword in some places.

Macro benchmarks are within noise: 
mazzzy@dingle:~/cpptracer/build$ hyperfine "./main_shading_sample.x -w 400 -h 400 -i 5"
Benchmark #1: ./main_shading_sample.x -w 400 -h 400 -i 5
  Time (mean ± σ):     544.8 ms ±  28.6 ms    [User: 1.910 s, System: 0.026 s]
  Range (min … max):   526.5 ms … 624.2 ms    10 runs

mazzzy@dingle:~/cpptracer/build$ hyperfine "./main_master.x -w 400 -h 400 -i 5"                                                                                                     
Benchmark #1: ./main_master.x -w 400 -h 400 -i 5
  Time (mean ± σ):     549.3 ms ±  44.3 ms    [User: 1.923 s, System: 0.025 s]
  Range (min … max):   516.9 ms … 632.0 ms    10 runs
