### PR TITLE
Returning copy of spectrum from material methods.

### DIFF
--- a/include/materials/blinn.h
+++ b/include/materials/blinn.h
@@ -11,8 +11,8 @@ class Blinn : public Material {
 
  public:
   Blinn(Spectrum*, Spectrum*, float);
-  Spectrum* evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
-  Spectrum* evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
+  Spectrum evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
+  Spectrum evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
 
   bool hasSpecularReflection() const override;
   bool hasSpecularRefraction() const override;

--- a/include/materials/diffuse.h
+++ b/include/materials/diffuse.h
@@ -12,8 +12,8 @@ class Diffuse : public Material {
 
  public:
   Diffuse(const Spectrum*);
-  Spectrum* evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
-  Spectrum* evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
+  Spectrum evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
+  Spectrum evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
 
   bool hasSpecularReflection() const override;
   bool hasSpecularRefraction() const override;

--- a/include/materials/explosionMaterial.h
+++ b/include/materials/explosionMaterial.h
@@ -24,8 +24,8 @@ class ExplosionMaterial : public Material {
  public:
   ExplosionMaterial(Spectrum*, Spectrum*, float);
 
-  Spectrum* evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
-  Spectrum* evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
+  Spectrum evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
+  Spectrum evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
 
   bool hasSpecularReflection() const override;
   bool hasSpecularRefraction() const override;

--- a/include/materials/gridTexturedMaterial.h
+++ b/include/materials/gridTexturedMaterial.h
@@ -19,8 +19,8 @@ class GridTexturedMaterial : public Material {
   GridTexturedMaterial(Spectrum* lineColor, Spectrum* tileColor, float thickness, Vector3f* shift,
                        float scale);
 
-  Spectrum* evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
-  Spectrum* evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
+  Spectrum evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
+  Spectrum evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
 
   bool hasSpecularReflection() const override;
   bool hasSpecularRefraction() const override;

--- a/include/materials/material.h
+++ b/include/materials/material.h
@@ -24,7 +24,7 @@ class Material {
    *  surface
    * @return BRDF value
    */
-  virtual Spectrum* evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const = 0;
+  virtual Spectrum evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const = 0;
 
   /**
    * Evaluate emission for outgoing direction. This method is typically
@@ -36,7 +36,7 @@ class Material {
    *  surface
    * @return emission value
    */
-  virtual Spectrum* evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const = 0;
+  virtual Spectrum evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const = 0;
 
   /**
    * Return whether material has perfect specular reflection.

--- a/include/materials/pointLightMaterial.h
+++ b/include/materials/pointLightMaterial.h
@@ -12,8 +12,8 @@ class PointLightMaterial : public Material {
 
  public:
   PointLightMaterial(Spectrum*);
-  Spectrum* evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
-  Spectrum* evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
+  Spectrum evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
+  Spectrum evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
 
   bool hasSpecularReflection() const override;
   bool hasSpecularRefraction() const override;

--- a/include/materials/reflectiveMaterial.h
+++ b/include/materials/reflectiveMaterial.h
@@ -15,8 +15,8 @@ class ReflectiveMaterial : public Material {
   ReflectiveMaterial();
   ReflectiveMaterial(Spectrum*);
 
-  Spectrum* evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
-  Spectrum* evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
+  Spectrum evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
+  Spectrum evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
 
   bool hasSpecularReflection() const override;
   bool hasSpecularRefraction() const override;

--- a/include/materials/refractiveMaterial.h
+++ b/include/materials/refractiveMaterial.h
@@ -20,8 +20,8 @@ class RefractiveMaterial : public Material {
   RefractiveMaterial(float);
   RefractiveMaterial(float, Spectrum*);
 
-  Spectrum* evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
-  Spectrum* evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
+  Spectrum evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const override;
+  Spectrum evaluateEmission(HitRecord* hitRecord, Vector3f* wOut) const override;
 
   bool hasSpecularReflection() const override;
   bool hasSpecularRefraction() const override;

--- a/src/materials/blinn.cpp
+++ b/src/materials/blinn.cpp
@@ -7,8 +7,8 @@ Blinn::Blinn(Spectrum* diffuseContribution, Spectrum* specularContribution, floa
       specularContribution(*specularContribution),
       shinynessPower(shinynessPower) {}
 
-Spectrum* Blinn::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const {
-  Spectrum* contribution = new Spectrum();
+Spectrum Blinn::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wIn) const {
+  Spectrum contribution;
   Spectrum diffuse = diffuseContribution;
   Spectrum specular = specularContribution;
   const Spectrum& ambient = diffuseContribution;
@@ -20,14 +20,14 @@ Spectrum* Blinn::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut, Vector3f* wI
   diffuse.scale(wIn->dot(*hitRecord->normal));
   specular.scale(pow(halfwayVector.dot(*hitRecord->normal), shinynessPower));
 
-  contribution->add(diffuse);
-  contribution->add(specular);
-  contribution->add(ambient);
+  contribution.add(diffuse);
+  contribution.add(specular);
+  contribution.add(ambient);
 
   return contribution;
 }
 
-Spectrum* Blinn::evaluateEmission(HitRecord*, Vector3f*) const { return new Spectrum(); }
+Spectrum Blinn::evaluateEmission(HitRecord*, Vector3f*) const { return Spectrum(); }
 
 bool Blinn::hasSpecularReflection() const { return false; }
 

--- a/src/materials/diffuse.cpp
+++ b/src/materials/diffuse.cpp
@@ -6,11 +6,9 @@ Diffuse::Diffuse(const Spectrum* emission) : emission(*emission) {
   this->emission.scale(1.0 / M_PI);
 }
 
-Spectrum* Diffuse::evaluateBrdf(HitRecord*, Vector3f*, Vector3f*) const {
-  return new Spectrum(emission);
-}
+Spectrum Diffuse::evaluateBrdf(HitRecord*, Vector3f*, Vector3f*) const { return emission; }
 
-Spectrum* Diffuse::evaluateEmission(HitRecord*, Vector3f*) const { return new Spectrum(); }
+Spectrum Diffuse::evaluateEmission(HitRecord*, Vector3f*) const { return Spectrum(); }
 
 bool Diffuse::hasSpecularReflection() const { return false; }
 

--- a/src/materials/explosionMaterial.cpp
+++ b/src/materials/explosionMaterial.cpp
@@ -8,8 +8,8 @@ ExplosionMaterial::ExplosionMaterial(Spectrum* diffuseContribution, Spectrum* sp
       specularContribution(*specularContribution),
       shinynessPower(shinynessPower) {}
 
-Spectrum* ExplosionMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut,
-                                          Vector3f* wIn) const {
+Spectrum ExplosionMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut,
+                                         Vector3f* wIn) const {
   Spectrum diffuse = Spectrum();
   Spectrum specular = specularContribution;
   Spectrum ambient = diffuseContribution;
@@ -39,17 +39,15 @@ Spectrum* ExplosionMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut,
   }
   diffuse.scale(wIn->dot(*hitRecord->normal));
 
-  Spectrum* contribution = new Spectrum();
-  contribution->add(diffuse);
-  contribution->add(specular);
-  contribution->add(ambient);
+  Spectrum contribution;
+  contribution.add(diffuse);
+  contribution.add(specular);
+  contribution.add(ambient);
 
   return contribution;
 }
 
-Spectrum* ExplosionMaterial::evaluateEmission(HitRecord*, Vector3f*) const {
-  return new Spectrum();
-}
+Spectrum ExplosionMaterial::evaluateEmission(HitRecord*, Vector3f*) const { return Spectrum(); }
 
 bool ExplosionMaterial::hasSpecularReflection() const { return false; }
 

--- a/src/materials/gridTexturedMaterial.cpp
+++ b/src/materials/gridTexturedMaterial.cpp
@@ -12,9 +12,9 @@ GridTexturedMaterial::GridTexturedMaterial(Spectrum* lineColor, Spectrum* tileCo
       scale(scale),
       diffuse(new Spectrum(1)) {}
 
-Spectrum* GridTexturedMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut,
-                                             Vector3f* wIn) const {
-  Spectrum* diffuseBRDF = diffuse.evaluateBrdf(hitRecord, wOut, wIn);
+Spectrum GridTexturedMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut,
+                                            Vector3f* wIn) const {
+  Spectrum diffuseBRDF = diffuse.evaluateBrdf(hitRecord, wOut, wIn);
 
   Vector3f* hitPoint = new Vector3f(*hitRecord->position);
 
@@ -33,14 +33,14 @@ Spectrum* GridTexturedMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOu
 
   if (shifted->x < relativeThickness || shifted->y < relativeThickness ||
       shifted->z < relativeThickness)
-    diffuseBRDF->mult(lineColor);
+    diffuseBRDF.mult(lineColor);
   else
-    diffuseBRDF->mult(tileColor);
+    diffuseBRDF.mult(tileColor);
 
   return diffuseBRDF;
 }
 
-Spectrum* GridTexturedMaterial::evaluateEmission(HitRecord* hitRecord, Vector3f* wIn) const {
+Spectrum GridTexturedMaterial::evaluateEmission(HitRecord* hitRecord, Vector3f* wIn) const {
   return diffuse.evaluateEmission(hitRecord, wIn);
 }
 

--- a/src/materials/pointLightMaterial.cpp
+++ b/src/materials/pointLightMaterial.cpp
@@ -3,13 +3,11 @@
 // TODO(panmari): Change constructor to only allow const ref. Currently, this is a memory leak.
 PointLightMaterial::PointLightMaterial(Spectrum* emission) : emission(*emission) {}
 
-Spectrum* PointLightMaterial::evaluateBrdf(HitRecord*, Vector3f*, Vector3f*) const {
-  return new Spectrum();
+Spectrum PointLightMaterial::evaluateBrdf(HitRecord*, Vector3f*, Vector3f*) const {
+  return Spectrum();
 }
 
-Spectrum* PointLightMaterial::evaluateEmission(HitRecord*, Vector3f*) const {
-  return new Spectrum(emission);
-}
+Spectrum PointLightMaterial::evaluateEmission(HitRecord*, Vector3f*) const { return emission; }
 
 bool PointLightMaterial::hasSpecularReflection() const { return false; }
 

--- a/src/materials/reflectiveMaterial.cpp
+++ b/src/materials/reflectiveMaterial.cpp
@@ -5,14 +5,12 @@ ReflectiveMaterial::ReflectiveMaterial() : ks(1, 1, 1) {}
 // TODO(panmari): Change constructor to expect a const ref. This is currently a memory leak.
 ReflectiveMaterial::ReflectiveMaterial(Spectrum* ks) : ks(*ks) {}
 
-Spectrum* ReflectiveMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut,
-                                           Vector3f* wIn) const {
-  return new Spectrum(1);
+Spectrum ReflectiveMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut,
+                                          Vector3f* wIn) const {
+  return Spectrum(1);
 }
 
-Spectrum* ReflectiveMaterial::evaluateEmission(HitRecord*, Vector3f*) const {
-  return new Spectrum();
-}
+Spectrum ReflectiveMaterial::evaluateEmission(HitRecord*, Vector3f*) const { return Spectrum(); }
 
 bool ReflectiveMaterial::hasSpecularReflection() const { return true; }
 

--- a/src/materials/refractiveMaterial.cpp
+++ b/src/materials/refractiveMaterial.cpp
@@ -47,14 +47,12 @@ RefractiveMaterial::RefractiveMaterial(float refractionIndex)
 RefractiveMaterial::RefractiveMaterial(float refractionIndex, Spectrum* ks)
     : refractionIndex(refractionIndex), ks(*ks) {}
 
-Spectrum* RefractiveMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut,
-                                           Vector3f* wIn) const {
-  return new Spectrum();
+Spectrum RefractiveMaterial::evaluateBrdf(HitRecord* hitRecord, Vector3f* wOut,
+                                          Vector3f* wIn) const {
+  return Spectrum();
 }
 
-Spectrum* RefractiveMaterial::evaluateEmission(HitRecord*, Vector3f*) const {
-  return new Spectrum();
-}
+Spectrum RefractiveMaterial::evaluateEmission(HitRecord*, Vector3f*) const { return Spectrum(); }
 
 bool RefractiveMaterial::hasSpecularReflection() const { return true; }
 


### PR DESCRIPTION
Benchmarks show runtime is not largely affected:

../external/googlebenchmark/tools/compare.py benchmarks ./benchmarks_integrator_sample.x ./benchmarks.x --benchmark_filter=BM_Whitted.* --benchmark_
display_aggregates_only --benchmark_repetitions=20

Output:
BM_WhittedIntegrator_pvalue                 0.0036          0.0033      U Test, Repetitions: 20 vs 20                                                                               
BM_WhittedIntegrator_mean                  -0.0047         -0.0047          5954          5926          5952          5924                                                          
BM_WhittedIntegrator_median                -0.0050         -0.0051          5950          5920          5949          5918                                                          
BM_WhittedIntegrator_stddev                -0.3523         -0.3523            32            21            32            21                                                          
