### PR TITLE
Fully use our Logger

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,17 +1,16 @@
-#include "exampleConfig.h"
 #include <iostream>
 #include <thread>
-#include "renderer.h"
-#include "cameraTest.h"
 #include "blinnTest.h"
+#include "cameraTest.h"
+#include "cxxopts.hpp"
+#include "exampleConfig.h"
 #include "explosionTest.h"
-#include "triangleTest.h"
+#include "logger.h"
+#include "meshTest.h"
 #include "reflectionTest.h"
 #include "refractiveScene.h"
-#include "meshTest.h"
-#include "cxxopts.hpp"
-
-using namespace std;
+#include "renderer.h"
+#include "triangleTest.h"
 
 cxxopts::ParseResult parse(int argc, char* argv[]) {
   // clang-format off
@@ -45,11 +44,12 @@ cxxopts::ParseResult parse(int argc, char* argv[]) {
 }
 
 int main(int argc, char *argv[]) {
-    cout << "C++ Raytracer v"
-         << PROJECT_VERSION_MAJOR
-         << "."
-         << PROJECT_VERSION_MINOR
-         << endl;
+    std::ostringstream oss;
+    oss << "C++ Raytracer v"
+        << PROJECT_VERSION_MAJOR
+        << "."
+        << PROJECT_VERSION_MINOR
+        << std::endl;
 
     auto result = parse(argc, argv);
 
@@ -60,10 +60,12 @@ int main(int argc, char *argv[]) {
     int sceneNr = result["i"].as<int>();
     int spp = result["s"].as<int>();
 
-    unsigned threadCount = thread::hardware_concurrency();
-    cout << "Using " << threadCount << " threads" << endl;
-    cout << "Rendering scene Nr " << sceneNr << endl;
-    cout << "Rendering " << spp << " sample(s) per pixel" << endl;
+    unsigned threadCount = std::thread::hardware_concurrency();
+    oss << "Using " << threadCount << " threads" << std::endl
+        << "Rendering scene Nr " << sceneNr << std::endl
+        << "Rendering " << spp << " sample(s) per pixel" << std::endl;
+
+    Logger().log(oss.str());
 
     Scene* scene;
     switch(sceneNr) {

--- a/include/logger.h
+++ b/include/logger.h
@@ -27,10 +27,11 @@ class Logger {
   std::string static toString(const Triangle&);
   std::string static toString(const MeshTriangle&);
   std::string static toString(const MeshData&);
+  std::string static toString(const std::string&);
 
   template <typename Loggable>
   inline void log(const Loggable& l) {
-    std::cout << toString(l) << std::endl;
+    std::cout << toString(l);
   }
 };
 #endif

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1,14 +1,17 @@
 #include "image.h"
+#include <logger.h>
 #include <stdio.h>
 #include <string.h>
 #include <cmath>
 #include <iostream>
+#include <sstream>
 
 Image::Image(int width, int height, const std::vector<Spectrum>& values, std::string filename)
     : width(width), height(height), values(values), filename(filename) {}
 
 void Image::print() {
-  std::cout << "Printing " << width << " x " << height << " image" << std::endl;
+  std::ostringstream oss;
+  oss << "Printing " << width << " x " << height << " image... ";
 
   int x;
   int y;
@@ -78,5 +81,8 @@ void Image::print() {
   free(img);
   fclose(f);
 
-  std::cout << "Saved image '" << filename << "'" << std::endl;
+  oss << "Done" << std::endl;
+  oss << "Saved image '" << filename << "'" << std::endl;
+
+  Logger().log(oss.str());
 }

--- a/src/intersectables/mesh.cpp
+++ b/src/intersectables/mesh.cpp
@@ -7,6 +7,7 @@
 Mesh::Mesh(Material* material, std::string filepath) : material(material) {
   MeshData mesh = ObjReader(filepath.c_str()).read();
   Logger().log(mesh);
+  Logger().log("\n");
 
   int faceIdx = 0;
   for (auto face : mesh.faces) {

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,8 +1,6 @@
 #include "logger.h"
 #include <stdio.h>
-#include <iostream>
 #include <sstream>
-#include <string>
 #include "hitRecord.h"
 #include "intersectables/meshTriangle.h"
 #include "intersectables/triangle.h"
@@ -109,4 +107,8 @@ std::string Logger::toString(const MeshData& md) {
       << "Normal Faces extracted: " << md.normalFaces.size();
 
   return oss.str();
+}
+
+std::string Logger::toString(const std::string& str) {
+  return str;
 }

--- a/src/progressBar.cpp
+++ b/src/progressBar.cpp
@@ -1,6 +1,7 @@
 #include "progressBar.h"
 #include <chrono>
 #include <iostream>
+#include "logger.h"
 
 ProgressBar::ProgressBar(std::vector<int>* taskCounters, int totalTasks)
     : taskCounters(taskCounters), totalTasks(totalTasks) {
@@ -8,6 +9,7 @@ ProgressBar::ProgressBar(std::vector<int>* taskCounters, int totalTasks)
 }
 
 void ProgressBar::update() {
+  Logger().log("Progress: ");
   while (isRunning) {
     int completedTaskCount = 0;
     for (auto& n : (*taskCounters)) {
@@ -16,9 +18,10 @@ void ProgressBar::update() {
 
     int tmpProgress = (completedTaskCount / stepSize) + 1;
     int diff = tmpProgress - progress;
-    std::cout << "";
+    Logger().log("");
+
     for (int k = 0; k < diff; k++) {
-      std::cout << "* ";
+      Logger().log("* ");
     }
     std::cout << std::flush;
     progress = tmpProgress;
@@ -31,5 +34,5 @@ void ProgressBar::start() { this->progressThread = new std::thread(&ProgressBar:
 void ProgressBar::stop() {
   isRunning = false;
   progressThread->join();
-  std::cout << std::endl;
+  Logger().log("\n");
 }


### PR DESCRIPTION
This patch replaces all `std::cout` statements by `Logger().log()`. This will enable use to store all console outputs in a logfile or mute the logging (e.g. useful when running the tests).