### PR TITLE
Support Constructive Solid Geometries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/include/intersectables/accelerator
   ${PROJECT_SOURCE_DIR}/include/intersectables/geometires
   ${PROJECT_SOURCE_DIR}/include/intersectables/containers
+  ${PROJECT_SOURCE_DIR}/include/intersectables/csg
   ${PROJECT_SOURCE_DIR}/include/materials
   ${PROJECT_SOURCE_DIR}/include/lights
   ${PROJECT_SOURCE_DIR}/include/integrators
@@ -67,7 +68,7 @@ include_directories(
 
 # Make variables referring to all the sources and test files.
 file(GLOB SOURCES "src/*.cpp")
-file(GLOB INTERSECTABLE_SOURCES "src/intersectables/*.cpp", "src/intersectables/accelerator/*.cpp", "src/intersectables/geometries/*.cpp", "src/intersectables/containers/*.cpp")
+file(GLOB INTERSECTABLE_SOURCES "src/intersectables/*.cpp", "src/intersectables/accelerator/*.cpp", "src/intersectables/geometries/*.cpp", "src/intersectables/containers/*.cpp", "src/intersectables/csg/*.cpp")
 file(GLOB MATERIAL_SOURCES "src/materials/*.cpp")
 file(GLOB LIGHT_SOURCES "src/lights/*.cpp")
 file(GLOB INTEGRATOR_SOURCES "src/integrators/*.cpp")

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "C++ Boiler Plate"
+PROJECT_NAME           = "Cpptracer"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -416,7 +416,7 @@ LOOKUP_CACHE_SIZE      = 0
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
@@ -772,8 +772,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT = @CMAKE_CURRENT_SOURCE_DIR@/README.md
-INPUT                  += @CMAKE_CURRENT_SOURCE_DIR@/include/ @CMAKE_CURRENT_SOURCE_DIR@/src
-
+INPUT += @CMAKE_CURRENT_SOURCE_DIR@/include/
+INPUT += @CMAKE_CURRENT_SOURCE_DIR@/src/
 
 FILE_PATTERNS += *.md *.markdown
 
@@ -800,13 +800,17 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f, *.for, *.tcl,
 # *.vhd, *.vhdl, *.ucf, *.qsf, *.as and *.js.
 
-FILE_PATTERNS          =
+FILE_PATTERNS          = *.cpp \
+                         *.hpp \
+                         *.c \
+                         *.h \
+                         *.md
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Inside `build/`, execute `./unit_tests.x`
 
 Inside `build/`, execute `./benchmarks.x`
 
+## Generate Documentation
+
+Inside `build/`, execute `make doc`
+
+
 ## Contributing
 
 1. Fork this repository

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 ## Features
 
- + Recursive raytracing (Whitted Integrator)
- + Can render [Constructive solid geometries](http://en.wikipedia.org/wiki/Constructive_solid_geometry)
- + Can process triangle meshes through the [.obj](https://en.wikipedia.org/wiki/Wavefront_.obj_file) format
- + Multithreaded
- + Supports reflective and refractive materials
++ Recursive raytracing (Whitted Integrator)
++ Can render [Constructive solid geometries](http://en.wikipedia.org/wiki/Constructive_solid_geometry)
++ Can process triangle meshes through the [.obj](https://en.wikipedia.org/wiki/Wavefront_.obj_file) format
++ Multithreaded
++ Supports reflective and refractive materials
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Inside `build/`, execute `./benchmarks.x`
 
 Inside `build/`, execute `make doc`
 
-
 ## Contributing
 
 1. Fork this repository

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 ## Features
 
-  + Recursive raytracing (Whitted Integrator)
-  + Can render [Constructive solid geometries](http://en.wikipedia.org/wiki/Constructive_solid_geometry)
-  + Can process triangle meshes through the [.obj](https://en.wikipedia.org/wiki/Wavefront_.obj_file) format
-  + Multithreaded
-  + Supports reflective and refractive materials
++ Recursive raytracing (Whitted Integrator)
++ Can render [Constructive solid geometries](http://en.wikipedia.org/wiki/Constructive_solid_geometry)
++ Can process triangle meshes through the [.obj](https://en.wikipedia.org/wiki/Wavefront_.obj_file) format
++ Multithreaded
++ Supports reflective and refractive materials
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 
 ![alt tag](https://github.com/simplay/cpptracer/blob/master/examples/blinn.bmp)
 
+## Features
+
+ + Recursive raytracing (Whitted Integrator)
+ + Can render [Constructive solid geometries](http://en.wikipedia.org/wiki/Constructive_solid_geometry)
+ + Can process triangle meshes through the [.obj](https://en.wikipedia.org/wiki/Wavefront_.obj_file) format
+ + Multithreaded
+ + Supports reflective and refractive materials
+
 ## Dependencies
 
 + `cmake >= 3.1.3`

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 ## Features
 
-+ Recursive raytracing (Whitted Integrator)
-+ Can render [Constructive solid geometries](http://en.wikipedia.org/wiki/Constructive_solid_geometry)
-+ Can process triangle meshes through the [.obj](https://en.wikipedia.org/wiki/Wavefront_.obj_file) format
-+ Multithreaded
-+ Supports reflective and refractive materials
+  + Recursive raytracing (Whitted Integrator)
+  + Can render [Constructive solid geometries](http://en.wikipedia.org/wiki/Constructive_solid_geometry)
+  + Can process triangle meshes through the [.obj](https://en.wikipedia.org/wiki/Wavefront_.obj_file) format
+  + Multithreaded
+  + Supports reflective and refractive materials
 
 ## Dependencies
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -10,6 +10,7 @@
 #include "reflectionTest.h"
 #include "refractiveScene.h"
 #include "renderer.h"
+#include "scenes/csgScene.h"
 #include "triangleTest.h"
 
 cxxopts::ParseResult parse(int argc, char* argv[]) {
@@ -90,6 +91,9 @@ int main(int argc, char *argv[]) {
         break;
       case 7:
         scene = new MeshTest(width, height);
+        break;
+      case 8:
+        scene = new CsgScene(width, height);
         break;
       default:
         scene = new CameraTest(width, height);

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,17 +1,17 @@
 #include <iostream>
 #include <thread>
-#include "blinnTest.h"
-#include "cameraTest.h"
 #include "cxxopts.hpp"
 #include "exampleConfig.h"
-#include "explosionTest.h"
 #include "logger.h"
-#include "meshTest.h"
-#include "reflectionTest.h"
-#include "refractiveScene.h"
 #include "renderer.h"
+#include "scenes/blinnTest.h"
+#include "scenes/cameraTest.h"
 #include "scenes/csgScene.h"
-#include "triangleTest.h"
+#include "scenes/explosionTest.h"
+#include "scenes/meshTest.h"
+#include "scenes/reflectionTest.h"
+#include "scenes/refractiveScene.h"
+#include "scenes/triangleTest.h"
 
 cxxopts::ParseResult parse(int argc, char* argv[]) {
   // clang-format off

--- a/include/intersectables/containers/instance.h
+++ b/include/intersectables/containers/instance.h
@@ -23,7 +23,7 @@ class Material;
  * many similar intersectable instances
  */
 class Instance : public Intersectable {
- protected:
+ private:
   // A reference to an intersectable, e.g. a sphere or a plane.
   Intersectable* intersectable;
 

--- a/include/intersectables/containers/instance.h
+++ b/include/intersectables/containers/instance.h
@@ -23,7 +23,7 @@ class Material;
  * many similar intersectable instances
  */
 class Instance : public Intersectable {
- private:
+ protected:
   // A reference to an intersectable, e.g. a sphere or a plane.
   Intersectable* intersectable;
 
@@ -46,8 +46,8 @@ class Instance : public Intersectable {
   Instance(Intersectable*, Matrix4f*);
   ~Instance();
 
-  HitRecord* intersect(const Ray& ray) const;
+  virtual HitRecord* intersect(const Ray& ray) const;
 
-  const BoundingBox& getBoundingBox() const;
+  virtual const BoundingBox& getBoundingBox() const;
 };
 #endif

--- a/include/intersectables/containers/intersectableList.h
+++ b/include/intersectables/containers/intersectableList.h
@@ -27,6 +27,7 @@ class IntersectableList : public Intersectable {
   const BoundingBox& getBoundingBox() const;
 
   void put(Intersectable*);
+  Intersectable* at(unsigned index) const;
   unsigned size() const;
 
   const std::vector<Intersectable*> getContainer() const { return container; }

--- a/include/intersectables/csg/csgInstance.h
+++ b/include/intersectables/csg/csgInstance.h
@@ -1,0 +1,21 @@
+#ifndef CSG_INSTANCE_H
+#define CSG_INSTANCE_H
+
+#include "hitRecord.h"
+#include "intersectables/accelerator/boundingBox.h"
+#include "intersectables/containers/instance.h"
+#include "intersectables/csg/csgSolid.h"
+#include "math/matrix4f.h"
+#include "math/vector3f.h"
+#include "ray.h"
+
+class CsgInstance : public CsgSolid, public Instance {
+ private:
+  CsgSolid* solid;
+
+ public:
+  CsgInstance(CsgSolid*);
+  CsgInstance(CsgSolid*, Matrix4f*);
+  std::vector<CsgSolid::IntervalBoundary> getIntervalBoundaries(const Ray& ray) const;
+};
+#endif

--- a/include/intersectables/csg/csgInstance.h
+++ b/include/intersectables/csg/csgInstance.h
@@ -9,13 +9,31 @@
 #include "math/vector3f.h"
 #include "ray.h"
 
-class CsgInstance : public CsgSolid, public Instance {
+class CsgInstance : public CsgSolid {
  private:
   CsgSolid* solid;
+
+  // homogeneous tranformation matrix T described in local object coordinate
+  // system, i.e. from object coordinates to world coords.
+  Matrix4f* transformation;
+
+  // homogeneous inverse tranformation T^-1 described in world coordinate
+  // system, i.e. from world space coordinates to local coords.
+  Matrix4f* invTransformation;
+
+  // homogeneous transposed inverse tranformation (T^-1)^t used to transform
+  // normals and tangent vectors, described in world coordinate system
+  Matrix4f* invTrasnposedTransformation;
+
+  BoundingBox aabb;
 
  public:
   CsgInstance(CsgSolid*);
   CsgInstance(CsgSolid*, Matrix4f*);
   std::vector<CsgSolid::IntervalBoundary> getIntervalBoundaries(const Ray& ray) const;
+
+  virtual HitRecord* intersect(const Ray& ray) const;
+
+  virtual const BoundingBox& getBoundingBox() const;
 };
 #endif

--- a/include/intersectables/csg/csgNode.h
+++ b/include/intersectables/csg/csgNode.h
@@ -1,0 +1,21 @@
+#ifndef CSG_NODE_H
+#define CSG_NODE_H
+
+#include "intersectables/csg/csgSolid.h"
+
+/**
+ * A CsgNode combines two CsgSolid instances by a binary set operation: Either
+ * by a union-, intersection or difference- operation.
+ */
+class CsgNode : public CsgSolid {
+  enum SetOperation { UNION = 0, INTERSECTION = 1, DIFFERENCE = 2 };
+
+ private:
+  const CsgSolid left;
+  const CsgSolid right;
+  const SetOperation operation;
+
+ public:
+  CsgNode(const CsgSolid& left, const CsgSolid& right, SetOperation operation);
+};
+#endif

--- a/include/intersectables/csg/csgNode.h
+++ b/include/intersectables/csg/csgNode.h
@@ -3,12 +3,13 @@
 
 #include "intersectables/csg/csgSolid.h"
 
+enum SetOperation { UNION = 0, INTERSECTION = 1, DIFFERENCE = 2 };
+
 /**
  * A CsgNode combines two CsgSolid instances by a binary set operation: Either
  * by a union-, intersection or difference- operation.
  */
 class CsgNode : public CsgSolid {
-  enum SetOperation { UNION = 0, INTERSECTION = 1, DIFFERENCE = 2 };
 
  private:
   const CsgSolid* left;
@@ -18,7 +19,7 @@ class CsgNode : public CsgSolid {
  public:
   CsgNode(const CsgSolid* left, const CsgSolid* right, SetOperation operation);
 
-  std::vector<IntervalBoundary> getIntervalBoundaries(Ray r) const;
+  std::vector<IntervalBoundary> getIntervalBoundaries(const Ray& ray) const;
 
 };
 #endif

--- a/include/intersectables/csg/csgNode.h
+++ b/include/intersectables/csg/csgNode.h
@@ -17,5 +17,8 @@ class CsgNode : public CsgSolid {
 
  public:
   CsgNode(const CsgSolid* left, const CsgSolid* right, SetOperation operation);
+
+  std::vector<IntervalBoundary> getIntervalBoundaries(Ray r) const;
+
 };
 #endif

--- a/include/intersectables/csg/csgNode.h
+++ b/include/intersectables/csg/csgNode.h
@@ -11,11 +11,11 @@ class CsgNode : public CsgSolid {
   enum SetOperation { UNION = 0, INTERSECTION = 1, DIFFERENCE = 2 };
 
  private:
-  const CsgSolid left;
-  const CsgSolid right;
+  const CsgSolid* left;
+  const CsgSolid* right;
   const SetOperation operation;
 
  public:
-  CsgNode(const CsgSolid& left, const CsgSolid& right, SetOperation operation);
+  CsgNode(const CsgSolid* left, const CsgSolid* right, SetOperation operation);
 };
 #endif

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -32,7 +32,7 @@ class CsgSolid : public Intersectable {
 
     BelongsTo belongsTo;
 
-    bool operator>(const IntervalBoundary& other) { return t > other.t; };
+    bool operator<(const IntervalBoundary& other) { return t < other.t; };
   };
 
   BoundingBox aabb = BoundingBox(Vector3f(std::numeric_limits<float>::min()),

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -49,5 +49,7 @@ class CsgSolid : public Intersectable {
    * @return boundaries of intersection intervals
    */
   virtual std::vector<IntervalBoundary> getIntervalBoundaries(Ray r) const = 0;
+
+  BoundaryType findBoundaryType(const HitRecord& hit, const Ray& ray);
 };
 #endif

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -15,7 +15,7 @@
  */
 class CsgSolid : public Intersectable {
  public:
-  enum BoundaryType { START = 0, END = 1 };
+  enum BoundaryType { UNKOWN = 0, START = 1, END = 2 };
   enum BelongsTo { LEFT = 0, RIGHT = 1 };
 
   /**
@@ -25,7 +25,7 @@ class CsgSolid : public Intersectable {
     // t value of intersection
     float t;
     // Type of boundary of intersection interval (start or end)
-    BoundaryType type;
+    BoundaryType type = BoundaryType::UNKOWN;
 
     // The hit record of the intersection
     HitRecord* hitRecord;

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -40,5 +40,14 @@ class CsgSolid : public Intersectable {
 
   virtual HitRecord* intersect(const Ray& ray) const;
   virtual const BoundingBox& getBoundingBox() const;
+
+	/**
+   * Compute the boundaries of the intersection intervals of this CSG solid
+   * with a ray.
+	 *
+	 * @param r the ray that intersects the CSG solid
+	 * @return boundaries of intersection intervals
+	 */
+	virtual std::vector<IntervalBoundary>& getIntervalBoundaries(Ray r) const = 0;
 };
 #endif

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -48,6 +48,6 @@ class CsgSolid : public Intersectable {
    * @param r the ray that intersects the CsgSolid
    * @return boundaries of intersection intervals
    */
-  virtual std::vector<IntervalBoundary>& getIntervalBoundaries(Ray r) const = 0;
+  virtual std::vector<IntervalBoundary> getIntervalBoundaries(Ray r) const = 0;
 };
 #endif

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -41,13 +41,13 @@ class CsgSolid : public Intersectable {
   virtual HitRecord* intersect(const Ray& ray) const;
   virtual const BoundingBox& getBoundingBox() const;
 
-	/**
-   * Compute the boundaries of the intersection intervals of this CSG solid
+  /**
+   * Compute the boundaries of the intersection intervals of this CsgSolid
    * with a ray.
-	 *
-	 * @param r the ray that intersects the CSG solid
-	 * @return boundaries of intersection intervals
-	 */
-	virtual std::vector<IntervalBoundary>& getIntervalBoundaries(Ray r) const = 0;
+   *
+   * @param r the ray that intersects the CsgSolid
+   * @return boundaries of intersection intervals
+   */
+  virtual std::vector<IntervalBoundary>& getIntervalBoundaries(Ray r) const = 0;
 };
 #endif

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -1,0 +1,23 @@
+#ifndef CSG_SOLID_H
+#define CSG_SOLID_H
+
+#include <limits>
+#include "hitRecord.h"
+#include "intersectables/accelerator/boundingBox.h"
+#include "intersectables/intersectable.h"
+#include "ray.h"
+
+/**
+ * A CsgSolid is an Intersectable that not just allows to get the closest hit
+ * point - when intersected by a ray - but also allows to query the start-and
+ * endpoint of an intersection with a ray (i.e. the so called intersection
+ * interval).
+ */
+class CsgSolid : public Intersectable {
+  BoundingBox aabb = BoundingBox(Vector3f(std::numeric_limits<float>::min()),
+                                 Vector3f(std::numeric_limits<float>::max()));
+
+  virtual HitRecord* intersect(const Ray& ray) const;
+  virtual const BoundingBox& getBoundingBox() const;
+};
+#endif

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -14,6 +14,27 @@
  * interval).
  */
 class CsgSolid : public Intersectable {
+ public:
+  enum BoundaryType { START = 0, END = 1 };
+  enum BelongsTo { LEFT = 0, RIGHT = 1 };
+
+  /**
+   * Boundary of an intersection interval.
+   */
+  struct IntervalBoundary {
+    // t value of intersection
+    float t;
+    // Type of boundary of intersection interval (start or end)
+    BoundaryType type;
+
+    // The hit record of the intersection
+    HitRecord hitRecord;
+
+    BelongsTo belongsTo;
+
+    bool operator>(const IntervalBoundary& other) { return t > other.t; };
+  };
+
   BoundingBox aabb = BoundingBox(Vector3f(std::numeric_limits<float>::min()),
                                  Vector3f(std::numeric_limits<float>::max()));
 

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -45,11 +45,11 @@ class CsgSolid : public Intersectable {
    * Compute the boundaries of the intersection intervals of this CsgSolid
    * with a ray.
    *
-   * @param r the ray that intersects the CsgSolid
+   * @param ray the ray that intersects the CsgSolid
    * @return boundaries of intersection intervals
    */
-  virtual std::vector<IntervalBoundary> getIntervalBoundaries(Ray r) const = 0;
+  virtual std::vector<IntervalBoundary> getIntervalBoundaries(const Ray& ray) const = 0;
 
-  BoundaryType findBoundaryType(const HitRecord& hit, const Ray& ray);
+  BoundaryType findBoundaryType(const HitRecord& hit, const Ray& ray) const;
 };
 #endif

--- a/include/intersectables/csg/csgSolid.h
+++ b/include/intersectables/csg/csgSolid.h
@@ -28,7 +28,7 @@ class CsgSolid : public Intersectable {
     BoundaryType type;
 
     // The hit record of the intersection
-    HitRecord hitRecord;
+    HitRecord* hitRecord;
 
     BelongsTo belongsTo;
 

--- a/include/intersectables/geometries/cube.h
+++ b/include/intersectables/geometries/cube.h
@@ -1,0 +1,59 @@
+#ifndef CUBE_H
+#define CUBE_H
+
+#include <limits>
+#include "hitRecord.h"
+#include "intersectables/accelerator/boundingBox.h"
+#include "intersectables/containers/intersectableList.h"
+#include "intersectables/csg/csgNode.h"
+#include "intersectables/csg/csgSolid.h"
+#include "intersectables/geometries/plane.h"
+#include "math/vector3f.h"
+#include "ray.h"
+
+class Material;
+
+class Cube : public CsgSolid {
+ private:
+  IntersectableList* sides;
+  Material* material;
+  const BoundingBox aabb;
+  CsgNode* root;
+
+  BoundingBox computeAABB() {
+    return BoundingBox(Vector3f(std::numeric_limits<float>::min()),
+                       Vector3f(std::numeric_limits<float>::max()));
+  }
+
+  CsgNode* computeRootNode(const Material*) {
+    auto right = new Plane(material, Vector3f(1.f, 0.f, 0.f), -1.0);
+    auto left = new Plane(material, Vector3f(-1.f, 0.f, 0.f), -1.0);
+    auto top = new Plane(material, Vector3f(0.f, 1.f, 0.f), -1.0);
+    auto bottom = new Plane(material, Vector3f(0.f, -1.f, 0.f), -1.0);
+    auto front = new Plane(material, Vector3f(0.f, 0.f, 1.f), -1.0);
+    auto back = new Plane(material, Vector3f(0.f, 0.f, -1.f), -1.0);
+
+    sides->put(right);
+    sides->put(left);
+    sides->put(top);
+    sides->put(bottom);
+    sides->put(front);
+    sides->put(back);
+
+    auto n1 = new CsgNode(top, left, SetOperation::INTERSECTION);
+    auto n2 = new CsgNode(top, bottom, SetOperation::INTERSECTION);
+    auto n3 = new CsgNode(front, back, SetOperation::INTERSECTION);
+    auto n4 = new CsgNode(n1, n2, SetOperation::INTERSECTION);
+    return new CsgNode(n3, n4, SetOperation::INTERSECTION);
+  }
+
+  HitRecord* buildHitRecord(float t, const Ray& ray) const;
+
+ public:
+  Cube(Material*);
+  virtual HitRecord* intersect(const Ray& ray) const;
+
+  const BoundingBox& getBoundingBox() const { return aabb; }
+  virtual std::vector<IntervalBoundary> getIntervalBoundaries(const Ray& ray) const;
+};
+#endif

--- a/include/intersectables/geometries/cube.h
+++ b/include/intersectables/geometries/cube.h
@@ -25,13 +25,13 @@ class Cube : public CsgSolid {
                        Vector3f(std::numeric_limits<float>::max()));
   }
 
-  CsgNode* computeRootNode(const Material*) {
-    auto right = new Plane(material, Vector3f(1.f, 0.f, 0.f), 1.0);
-    auto left = new Plane(material, Vector3f(-1.f, 0.f, 0.f), 1.0);
-    auto top = new Plane(material, Vector3f(0.f, 1.f, 0.f), 1.0);
-    auto bottom = new Plane(material, Vector3f(0.f, -1.f, 0.f), 1.0);
-    auto front = new Plane(material, Vector3f(0.f, 0.f, 1.f), 1.0);
-    auto back = new Plane(material, Vector3f(0.f, 0.f, -1.f), 1.0);
+  CsgNode* computeRootNode(Material*) {
+    auto right = new Plane(material, Vector3f(1.0, 0.0, 0.0), 1.0);
+    auto left = new Plane(material, Vector3f(-1.0, 0.0, 0.0), 1.0);
+    auto top = new Plane(material, Vector3f(0.0, 1.0, 0.0), 1.0);
+    auto bottom = new Plane(material, Vector3f(0.0, -1.0, 0.0), 1.0);
+    auto front = new Plane(material, Vector3f(0.0, 0.0, 1.0), 1.0);
+    auto back = new Plane(material, Vector3f(0.0, 0.0, -1.0), 1.0);
 
     sides->put(right);
     sides->put(left);

--- a/include/intersectables/geometries/cube.h
+++ b/include/intersectables/geometries/cube.h
@@ -26,12 +26,12 @@ class Cube : public CsgSolid {
   }
 
   CsgNode* computeRootNode(const Material*) {
-    auto right = new Plane(material, Vector3f(1.f, 0.f, 0.f), -1.0);
-    auto left = new Plane(material, Vector3f(-1.f, 0.f, 0.f), -1.0);
-    auto top = new Plane(material, Vector3f(0.f, 1.f, 0.f), -1.0);
-    auto bottom = new Plane(material, Vector3f(0.f, -1.f, 0.f), -1.0);
-    auto front = new Plane(material, Vector3f(0.f, 0.f, 1.f), -1.0);
-    auto back = new Plane(material, Vector3f(0.f, 0.f, -1.f), -1.0);
+    auto right = new Plane(material, Vector3f(1.f, 0.f, 0.f), 1.0);
+    auto left = new Plane(material, Vector3f(-1.f, 0.f, 0.f), 1.0);
+    auto top = new Plane(material, Vector3f(0.f, 1.f, 0.f), 1.0);
+    auto bottom = new Plane(material, Vector3f(0.f, -1.f, 0.f), 1.0);
+    auto front = new Plane(material, Vector3f(0.f, 0.f, 1.f), 1.0);
+    auto back = new Plane(material, Vector3f(0.f, 0.f, -1.f), 1.0);
 
     sides->put(right);
     sides->put(left);
@@ -40,7 +40,7 @@ class Cube : public CsgSolid {
     sides->put(front);
     sides->put(back);
 
-    auto n1 = new CsgNode(top, left, SetOperation::INTERSECTION);
+    auto n1 = new CsgNode(right, left, SetOperation::INTERSECTION);
     auto n2 = new CsgNode(top, bottom, SetOperation::INTERSECTION);
     auto n3 = new CsgNode(front, back, SetOperation::INTERSECTION);
     auto n4 = new CsgNode(n1, n2, SetOperation::INTERSECTION);

--- a/include/intersectables/geometries/cylinder.h
+++ b/include/intersectables/geometries/cylinder.h
@@ -1,0 +1,40 @@
+#ifndef CYLINDER_H
+#define CYLINDER_H
+
+#include "hitRecord.h"
+#include "intersectables/accelerator/boundingBox.h"
+#include "intersectables/csg/csgSolid.h"
+#include "math/vector3f.h"
+#include "ray.h"
+
+class Material;
+
+class Cylinder : public CsgSolid {
+ private:
+  Material* material;
+  const BoundingBox aabb;
+
+  BoundingBox computeAABB() {
+    Vector3f center(0, 0, 0);
+    float radius = 1;
+    auto bottomLeft = Vector3f(center);
+    auto shift = Vector3f(-radius, -radius, -radius);
+    bottomLeft.add(shift);
+
+    auto topRight = Vector3f(center);
+    shift = Vector3f(radius, radius, radius);
+    topRight.add(shift);
+
+    return BoundingBox(bottomLeft, topRight);
+  }
+
+  HitRecord* buildHitRecord(float t, const Ray& ray) const;
+
+ public:
+  Cylinder(Material*);
+  virtual HitRecord* intersect(const Ray& ray) const;
+
+  const BoundingBox& getBoundingBox() const { return aabb; }
+  virtual std::vector<IntervalBoundary> getIntervalBoundaries(const Ray& ray) const;
+};
+#endif

--- a/include/intersectables/geometries/cylinder.h
+++ b/include/intersectables/geometries/cylinder.h
@@ -16,10 +16,10 @@ class Cylinder : public CsgSolid {
  private:
   Material* material;
   const BoundingBox aabb;
+  float radius;
 
   BoundingBox computeAABB() {
     Vector3f center(0, 0, 0);
-    float radius = 1;
     auto bottomLeft = Vector3f(center);
     auto shift = Vector3f(-radius, -radius, -radius);
     bottomLeft.add(shift);
@@ -34,7 +34,8 @@ class Cylinder : public CsgSolid {
   HitRecord* buildHitRecord(float t, const Ray& ray) const;
 
  public:
-  Cylinder(Material*);
+  Cylinder(Material* material);
+  Cylinder(Material* material, float radius);
   virtual HitRecord* intersect(const Ray& ray) const;
 
   const BoundingBox& getBoundingBox() const { return aabb; }

--- a/include/intersectables/geometries/cylinder.h
+++ b/include/intersectables/geometries/cylinder.h
@@ -9,6 +9,9 @@
 
 class Material;
 
+/**
+ * Infinite cylinder along z-axis with radius 1.
+ **/
 class Cylinder : public CsgSolid {
  private:
   Material* material;

--- a/include/intersectables/geometries/plane.h
+++ b/include/intersectables/geometries/plane.h
@@ -4,7 +4,7 @@
 #include <limits>
 #include "hitRecord.h"
 #include "intersectables/accelerator/boundingBox.h"
-#include "intersectables/intersectable.h"
+#include "intersectables/csg/csgSolid.h"
 #include "math/vector3f.h"
 #include "ray.h"
 
@@ -13,7 +13,7 @@ class Material;
 // Construct a plane given its normal and distance to the origin Note that the
 // distance is along the direction that the normal points (meaning that the
 // sign of distance matters)
-class Plane : public Intersectable {
+class Plane : public CsgSolid {
  private:
   BoundingBox initBoundingBox() {
     return BoundingBox(Vector3f(std::numeric_limits<float>::min()),
@@ -44,5 +44,7 @@ class Plane : public Intersectable {
   virtual HitRecord* intersect(const Ray& ray) const;
 
   const BoundingBox& getBoundingBox() const { return aabb; }
+
+  virtual std::vector<IntervalBoundary> getIntervalBoundaries(const Ray& ray) const;
 };
 #endif

--- a/include/intersectables/geometries/sphere.h
+++ b/include/intersectables/geometries/sphere.h
@@ -3,13 +3,13 @@
 
 #include "hitRecord.h"
 #include "intersectables/accelerator/boundingBox.h"
-#include "intersectables/intersectable.h"
+#include "intersectables/csg/csgSolid.h"
 #include "math/vector3f.h"
 #include "ray.h"
 
 class Material;
 
-class Sphere : public Intersectable {
+class Sphere : public CsgSolid {
  private:
   Material* material;
   const Vector3f center;
@@ -28,10 +28,13 @@ class Sphere : public Intersectable {
     return BoundingBox(bottomLeft, topRight);
   }
 
+  HitRecord* buildHitRecord(float t, const Ray& ray) const;
+
  public:
   Sphere(Material*, const Vector3f&, float);
   virtual HitRecord* intersect(const Ray& ray) const;
 
   const BoundingBox& getBoundingBox() const { return aabb; }
+  virtual std::vector<IntervalBoundary> getIntervalBoundaries(const Ray& ray) const;
 };
 #endif

--- a/include/math/matrix4f.h
+++ b/include/math/matrix4f.h
@@ -1,6 +1,7 @@
 #ifndef MATRIX4F_H
 #define MATRIX4F_H
 
+#include <cmath>
 #include "vector4f.h"
 
 class Matrix4f {
@@ -16,8 +17,63 @@ class Matrix4f {
   Matrix4f(float m00, float m01, float m02, float m03, float m10, float m11, float m12, float m13,
            float m20, float m21, float m22, float m23, float m30, float m31, float m32, float m33);
 
-  static Matrix4f* eye() { return new Matrix4f(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1); }
+  static Matrix4f* eye() {
+    // clang-format off
+    return new Matrix4f(
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    );
+    // clang-format on
+  }
 
+  /**
+   * @param angle value between 0 and 2*pi
+   * @return homogeneous transformation matrix
+   **/
+  static Matrix4f* rotX(float angle) {
+    // clang-format off
+    return new Matrix4f(
+      1, 0, 0, 0,
+      0, cos(angle), -sin(angle), 0,
+      0, sin(angle),  cos(angle), 0,
+      0, 0,           0,          1
+    );
+    // clang-format on
+  }
+
+  /**
+   * @param angle value between 0 and 2*pi
+   * @return homogeneous transformation matrix
+   **/
+  static Matrix4f* rotY(float angle) {
+    // clang-format off
+    return new Matrix4f(
+      cos(angle), 0, sin(angle), 0,
+      0,          1, 0,          0,
+     -sin(angle), 0, cos(angle), 0,
+      0,          0, 0,          1
+    );
+    // clang-format on
+  }
+
+  /**
+   * @param angle value between 0 and 2*pi
+   * @return homogeneous transformation matrix
+   **/
+  static Matrix4f* rotZ(float angle) {
+    // clang-format off
+    return new Matrix4f(
+      cos(angle), -sin(angle), 0, 0,
+      sin(angle),  cos(angle), 0, 0,
+      0,           0,          1, 0,
+      0,           0,          0, 1
+    );
+    // clang-format on
+  }
+
+  Matrix4f* mult(const Matrix4f& other);
   Vector4f* mult(const Vector4f& other);
   void scale(float f);
 

--- a/include/math/quadraticSolver.h
+++ b/include/math/quadraticSolver.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include "ray.h"
 
 /**
  * Float valued point with 3 coordinates.

--- a/include/math/quadraticSolver.h
+++ b/include/math/quadraticSolver.h
@@ -1,0 +1,20 @@
+#ifndef QUADRATIC_SOLVER_H
+#define QUADRATIC_SOLVER_H
+
+#include <string>
+#include <vector>
+
+/**
+ * Float valued point with 3 coordinates.
+ */
+class QuadraticSolver {
+ private:
+  float a;
+  float b;
+  float c;
+
+ public:
+  QuadraticSolver(const float a, const float b, const float c);
+  std::vector<float> solve();
+};
+#endif

--- a/include/scenes/csgScene.h
+++ b/include/scenes/csgScene.h
@@ -1,0 +1,15 @@
+#ifndef CSG_SCENE_H
+#define CSG_SCENE_H
+
+#include "scene.h"
+
+class CsgScene : public Scene {
+  public:
+    CsgScene(int width, int height);
+    void buildCamera();
+    void buildLights();
+    void buildIntersectables();
+    void buildIntegrator();
+    std::string filename() { return "csg_scene.bmp"; }
+};
+#endif

--- a/src/intersectables/containers/intersectableList.cpp
+++ b/src/intersectables/containers/intersectableList.cpp
@@ -42,4 +42,8 @@ void IntersectableList::put(Intersectable* intersectable) {
   aabb.expand(intersectable);
 }
 
+Intersectable* IntersectableList::at(unsigned index) const {
+  return container.at(index);
+}
+
 unsigned IntersectableList::size() const { return container.size(); }

--- a/src/intersectables/csg/csgInstance.cpp
+++ b/src/intersectables/csg/csgInstance.cpp
@@ -1,0 +1,23 @@
+#include "intersectables/csg/csgInstance.h"
+#include <memory>
+
+CsgInstance::CsgInstance(CsgSolid* solid) : Instance(solid), solid(solid) {}
+
+CsgInstance::CsgInstance(CsgSolid* solid, Matrix4f* transformation)
+    : Instance(solid, transformation), solid(solid) {}
+
+std::vector<CsgSolid::IntervalBoundary> CsgInstance::getIntervalBoundaries(const Ray& ray) const {
+  std::vector<IntervalBoundary> boundaries;
+  auto transRay = std::unique_ptr<Ray>(ray.transform(invTransformation));
+  auto intervalBoundaries = solid->getIntervalBoundaries(*transRay);
+
+  for (auto& interval : intervalBoundaries) {
+    auto hit = interval.hitRecord;
+    if (hit->isValid()) {
+      auto finalHit = hit->transform(transformation, invTrasnposedTransformation);
+      interval.hitRecord = finalHit;
+    }
+  }
+
+  return boundaries;
+}

--- a/src/intersectables/csg/csgInstance.cpp
+++ b/src/intersectables/csg/csgInstance.cpp
@@ -1,10 +1,19 @@
 #include "intersectables/csg/csgInstance.h"
 #include <memory>
 
-CsgInstance::CsgInstance(CsgSolid* solid) : Instance(solid), solid(solid) {}
+CsgInstance::CsgInstance(CsgSolid* solid)
+    : solid(solid), transformation(Matrix4f().eye()), aabb(solid->getBoundingBox()) {
+  this->invTransformation = Matrix4f().eye();
+  this->invTrasnposedTransformation = Matrix4f().eye();
+}
 
 CsgInstance::CsgInstance(CsgSolid* solid, Matrix4f* transformation)
-    : Instance(solid, transformation), solid(solid) {}
+    : solid(solid),
+      transformation(transformation),
+      aabb(solid->getBoundingBox().transform(*transformation)) {
+  this->invTransformation = transformation->inv();
+  this->invTrasnposedTransformation = invTransformation->transposed();
+}
 
 std::vector<CsgSolid::IntervalBoundary> CsgInstance::getIntervalBoundaries(const Ray& ray) const {
   std::vector<IntervalBoundary> boundaries;
@@ -21,3 +30,19 @@ std::vector<CsgSolid::IntervalBoundary> CsgInstance::getIntervalBoundaries(const
 
   return boundaries;
 }
+
+HitRecord* CsgInstance::intersect(const Ray& ray) const {
+  auto transRay = std::unique_ptr<Ray>(ray.transform(invTransformation));
+
+  auto hit = solid->intersect(*transRay);
+  if (!hit->isValid()) {
+    return hit;
+  }
+
+  auto finalHit = hit->transform(transformation, invTrasnposedTransformation);
+  delete hit;
+
+  return finalHit;
+}
+
+const BoundingBox& CsgInstance::getBoundingBox() const { return aabb; }

--- a/src/intersectables/csg/csgNode.cpp
+++ b/src/intersectables/csg/csgNode.cpp
@@ -1,4 +1,11 @@
 #include "intersectables/csg/csgNode.h"
+#include "ray.h"
 
 CsgNode::CsgNode(const CsgSolid* left, const CsgSolid* right, SetOperation operation)
     : left(left), right(right), operation(operation) {}
+
+std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(Ray r) const {
+  std::vector<CsgNode::IntervalBoundary> combined(100);
+
+  return combined;
+}

--- a/src/intersectables/csg/csgNode.cpp
+++ b/src/intersectables/csg/csgNode.cpp
@@ -62,5 +62,5 @@ std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(Ray ray) c
     prev.type = interval.type;
   }
 
-  return combined;
+  return finalCombination;
 }

--- a/src/intersectables/csg/csgNode.cpp
+++ b/src/intersectables/csg/csgNode.cpp
@@ -1,4 +1,4 @@
 #include "intersectables/csg/csgNode.h"
 
-CsgNode::CsgNode(const CsgSolid& left, const CsgSolid& right, SetOperation operation)
+CsgNode::CsgNode(const CsgSolid* left, const CsgSolid* right, SetOperation operation)
     : left(left), right(right), operation(operation) {}

--- a/src/intersectables/csg/csgNode.cpp
+++ b/src/intersectables/csg/csgNode.cpp
@@ -6,7 +6,7 @@ CsgNode::CsgNode(const CsgSolid* left, const CsgSolid* right, SetOperation opera
     : left(left), right(right), operation(operation) {}
 
 std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(const Ray& ray) const {
-  std::vector<CsgNode::IntervalBoundary> combined(100);
+  std::vector<CsgNode::IntervalBoundary> combined;
 
   auto leftIntervals = left->getIntervalBoundaries(ray);
   auto rightIntervals = right->getIntervalBoundaries(ray);
@@ -16,12 +16,12 @@ std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(const Ray&
     leftInterval.belongsTo = BelongsTo::LEFT;
   }
 
-  for (auto& rightInterval : leftIntervals) {
+  for (auto& rightInterval : rightIntervals) {
     rightInterval.belongsTo = BelongsTo::RIGHT;
   }
 
-  combined.insert(std::end(leftIntervals), std::begin(leftIntervals), std::end(leftIntervals));
-  combined.insert(std::end(rightIntervals), std::begin(rightIntervals), std::end(rightIntervals));
+  combined.insert(combined.end(), leftIntervals.begin(), leftIntervals.end());
+  combined.insert(combined.end(), rightIntervals.begin(), rightIntervals.end());
 
   // Sort members according to "<" operator defined in IntervalBoundary struct
   std::sort(combined.begin(), combined.end());
@@ -29,8 +29,13 @@ std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(const Ray&
   bool inLeft = false;
   bool inRight = false;
   for (auto& interval : combined) {
-    inLeft = interval.belongsTo == BelongsTo::LEFT && interval.type == BoundaryType::START;
-    inRight = interval.belongsTo == BelongsTo::RIGHT && interval.type == BoundaryType::START;
+    if (interval.belongsTo == BelongsTo::LEFT) {
+      inLeft = interval.type == BoundaryType::START;
+    }
+
+    if (interval.belongsTo == BelongsTo::RIGHT) {
+      inRight = interval.type == BoundaryType::START;
+    }
 
     switch (operation) {
       case INTERSECTION:
@@ -54,9 +59,9 @@ std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(const Ray&
   // clean up
   CsgSolid::IntervalBoundary prev;
   prev.type = BoundaryType::END;
-  std::vector<CsgNode::IntervalBoundary> finalCombination(100);
+  std::vector<CsgNode::IntervalBoundary> finalCombination;
   for (auto& interval : combined) {
-    if (interval.type != prev.type) {
+    if (interval.type != prev.type || interval.type == BoundaryType::UNKOWN) {
       finalCombination.push_back(interval);
     }
     prev.type = interval.type;

--- a/src/intersectables/csg/csgNode.cpp
+++ b/src/intersectables/csg/csgNode.cpp
@@ -1,11 +1,66 @@
 #include "intersectables/csg/csgNode.h"
+#include <algorithm>
 #include "ray.h"
 
 CsgNode::CsgNode(const CsgSolid* left, const CsgSolid* right, SetOperation operation)
     : left(left), right(right), operation(operation) {}
 
-std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(Ray r) const {
+std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(Ray ray) const {
   std::vector<CsgNode::IntervalBoundary> combined(100);
+
+  auto leftIntervals = left->getIntervalBoundaries(ray);
+  auto rightIntervals = right->getIntervalBoundaries(ray);
+
+  // mark interval boundaries as left- or right node
+  for (auto& leftInterval : leftIntervals) {
+    leftInterval.belongsTo = BelongsTo::LEFT;
+  }
+
+  for (auto& rightInterval : leftIntervals) {
+    rightInterval.belongsTo = BelongsTo::RIGHT;
+  }
+
+  combined.insert(std::end(leftIntervals), std::begin(leftIntervals), std::end(leftIntervals));
+  combined.insert(std::end(rightIntervals), std::begin(rightIntervals), std::end(rightIntervals));
+
+  // Sort members according to "<" operator defined in IntervalBoundary struct
+  std::sort(combined.begin(), combined.end());
+
+  bool inLeft = false;
+  bool inRight = false;
+  for (auto& interval : combined) {
+    inLeft = interval.belongsTo == BelongsTo::LEFT && interval.type == BoundaryType::START;
+    inRight = interval.belongsTo == BelongsTo::RIGHT && interval.type == BoundaryType::START;
+
+    switch (operation) {
+      case INTERSECTION:
+        interval.type = (inLeft && inRight) ? BoundaryType::START : BoundaryType::END;
+        break;
+      case UNION:
+        interval.type = (inLeft || inRight) ? BoundaryType::START : BoundaryType::END;
+        break;
+      case DIFFERENCE:
+        interval.type = (inLeft && !inRight) ? BoundaryType::START : BoundaryType::END;
+
+        // In a subtract operation, the subtracted solid is turned inside out,
+        // or it "switches sign", so we need to flip its normal direction
+        if (interval.belongsTo == BelongsTo::RIGHT && interval.hitRecord->isValid()) {
+          interval.hitRecord->normal->negate();
+        }
+        break;
+    }
+  }
+
+  // clean up
+  CsgSolid::IntervalBoundary prev;
+  prev.type = BoundaryType::END;
+  std::vector<CsgNode::IntervalBoundary> finalCombination(100);
+  for (auto& interval : combined) {
+    if (interval.type != prev.type) {
+      finalCombination.push_back(interval);
+    }
+    prev.type = interval.type;
+  }
 
   return combined;
 }

--- a/src/intersectables/csg/csgNode.cpp
+++ b/src/intersectables/csg/csgNode.cpp
@@ -1,0 +1,4 @@
+#include "intersectables/csg/csgNode.h"
+
+CsgNode::CsgNode(const CsgSolid& left, const CsgSolid& right, SetOperation operation)
+    : left(left), right(right), operation(operation) {}

--- a/src/intersectables/csg/csgNode.cpp
+++ b/src/intersectables/csg/csgNode.cpp
@@ -5,7 +5,7 @@
 CsgNode::CsgNode(const CsgSolid* left, const CsgSolid* right, SetOperation operation)
     : left(left), right(right), operation(operation) {}
 
-std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(Ray ray) const {
+std::vector<CsgNode::IntervalBoundary> CsgNode::getIntervalBoundaries(const Ray& ray) const {
   std::vector<CsgNode::IntervalBoundary> combined(100);
 
   auto leftIntervals = left->getIntervalBoundaries(ray);

--- a/src/intersectables/csg/csgSolid.cpp
+++ b/src/intersectables/csg/csgSolid.cpp
@@ -1,0 +1,10 @@
+#include "intersectables/csg/csgSolid.h"
+
+HitRecord* CsgSolid::intersect(const Ray& ray) const {
+  // TODO: implement me
+  return new HitRecord();
+}
+
+const BoundingBox& CsgSolid::getBoundingBox() const {
+  return aabb;
+}

--- a/src/intersectables/csg/csgSolid.cpp
+++ b/src/intersectables/csg/csgSolid.cpp
@@ -14,6 +14,4 @@ HitRecord* CsgSolid::intersect(const Ray& ray) const {
   return new HitRecord();
 }
 
-const BoundingBox& CsgSolid::getBoundingBox() const {
-  return aabb;
-}
+const BoundingBox& CsgSolid::getBoundingBox() const { return aabb; }

--- a/src/intersectables/csg/csgSolid.cpp
+++ b/src/intersectables/csg/csgSolid.cpp
@@ -15,3 +15,11 @@ HitRecord* CsgSolid::intersect(const Ray& ray) const {
 }
 
 const BoundingBox& CsgSolid::getBoundingBox() const { return aabb; }
+
+CsgSolid::BoundaryType CsgSolid::findBoundaryType(const HitRecord& hit, const Ray& ray) {
+  if (hit.normal->dot(*ray.direction) < 0.0) {
+    return BoundaryType::START;
+  } else {
+    return BoundaryType::END;
+  }
+}

--- a/src/intersectables/csg/csgSolid.cpp
+++ b/src/intersectables/csg/csgSolid.cpp
@@ -16,7 +16,7 @@ HitRecord* CsgSolid::intersect(const Ray& ray) const {
 
 const BoundingBox& CsgSolid::getBoundingBox() const { return aabb; }
 
-CsgSolid::BoundaryType CsgSolid::findBoundaryType(const HitRecord& hit, const Ray& ray) {
+CsgSolid::BoundaryType CsgSolid::findBoundaryType(const HitRecord& hit, const Ray& ray) const {
   if (hit.normal->dot(*ray.direction) < 0.0) {
     return BoundaryType::START;
   } else {

--- a/src/intersectables/csg/csgSolid.cpp
+++ b/src/intersectables/csg/csgSolid.cpp
@@ -1,7 +1,16 @@
 #include "intersectables/csg/csgSolid.h"
 
 HitRecord* CsgSolid::intersect(const Ray& ray) const {
-  // TODO: implement me
+  auto intervalBoundaries = getIntervalBoundaries(ray);
+
+  // Return the first hit in front of the camera, that is, make sure
+  // the hit is along the positive ray direction
+  for (auto const& intervalBoundary : intervalBoundaries) {
+    auto hit = intervalBoundary.hitRecord;
+    if (hit->isValid() && hit->t > 0.0) {
+      return hit;
+    }
+  }
   return new HitRecord();
 }
 

--- a/src/intersectables/geometries/cube.cpp
+++ b/src/intersectables/geometries/cube.cpp
@@ -1,0 +1,16 @@
+#include "intersectables/geometries/cube.h"
+#include <iostream>
+
+Cube::Cube(Material* material)
+    : sides(new IntersectableList()),
+      material(material),
+      aabb(computeAABB()),
+      root(computeRootNode(material)) {}
+
+std::vector<CsgSolid::IntervalBoundary> Cube::getIntervalBoundaries(const Ray& ray) const {
+  return root->getIntervalBoundaries(ray);
+}
+
+HitRecord* Cube::intersect(const Ray& ray) const {
+  return sides->intersect(ray);
+}

--- a/src/intersectables/geometries/cylinder.cpp
+++ b/src/intersectables/geometries/cylinder.cpp
@@ -1,0 +1,96 @@
+#include "intersectables/geometries/cylinder.h"
+#include <cmath>
+#include <iostream>
+
+HitRecord* Cylinder::buildHitRecord(float t, const Ray& ray) const {
+  auto hitPosition = ray.pointAt(t);
+  auto hitNormal = new Vector3f(*hitPosition);
+
+  auto wIn = Vector3f().incidentDirection(*ray.direction);
+
+  // clang-format off
+  return new HitRecord(
+      t,
+      hitPosition,
+      hitNormal,
+      new Vector3f(),
+      wIn,
+      material,
+      this,
+      ray.i,
+      ray.j
+      );
+  // clang-format on
+}
+
+Cylinder::Cylinder(Material* material) : material(material), aabb(computeAABB()) {}
+
+HitRecord* Cylinder::intersect(const Ray& ray) const {
+  auto rdx = ray.direction->x;
+  auto rdy = ray.direction->y;
+
+  auto rex = ray.origin->x;
+  auto rey = ray.origin->y;
+
+  float a = rdx * rdx + rdy * rdy;
+  float b = 2.0 * rex * rdx + 2.0 * rey * rdy;
+  float c = rex * rex + rey * rey - 1;
+
+  float discriminant = b * b - 4 * a * c;
+
+  if (discriminant < 0) {
+    return new HitRecord();
+  } else {
+    float t1 = (-b + sqrt(discriminant)) / (2.0 * a);
+    float t2 = (-b - sqrt(discriminant)) / (2.0 * a);
+
+    float t = std::min(t1, t2);
+    if (t < 0) {
+      t = std::max(t1, t2);
+      if (t < 0) {
+        return new HitRecord();
+      }
+    }
+
+    return buildHitRecord(t, ray);
+  }
+}
+
+std::vector<CsgSolid::IntervalBoundary> Cylinder::getIntervalBoundaries(const Ray& ray) const {
+  std::vector<IntervalBoundary> boundaries;
+  auto rdx = ray.direction->x;
+  auto rdy = ray.direction->y;
+
+  auto rex = ray.origin->x;
+  auto rey = ray.origin->y;
+
+  float a = rdx * rdx + rdy * rdy;
+  float b = 2.0 * rex * rdx + 2.0 * rey * rdy;
+  float c = rex * rex + rey * rey - 1;
+
+  float discriminant = b * b - 4 * a * c;
+
+  if (discriminant < 0) {
+    return boundaries;
+  }
+
+  float t1 = (-b + sqrt(discriminant)) / (2.0 * a);
+  float t2 = (-b - sqrt(discriminant)) / (2.0 * a);
+
+  auto hit1 = buildHitRecord(t1, ray);
+  IntervalBoundary b1;
+  b1.t = hit1->t;
+  b1.type = findBoundaryType(hit1, ray);
+  b1.hitRecord = hit1;
+
+  auto hit2 = buildHitRecord(t2, ray);
+  IntervalBoundary b2;
+  b2.t = hit2->t;
+  b2.type = findBoundaryType(hit2, ray);
+  b2.hitRecord = hit2;
+
+  boundaries.push_back(b1);
+  boundaries.push_back(b2);
+
+  return boundaries;
+}

--- a/src/intersectables/geometries/cylinder.cpp
+++ b/src/intersectables/geometries/cylinder.cpp
@@ -1,6 +1,6 @@
 #include "intersectables/geometries/cylinder.h"
-#include <cmath>
 #include <iostream>
+#include <math/quadraticSolver.h>
 
 HitRecord* Cylinder::buildHitRecord(float t, const Ray& ray) const {
   auto hitPosition = ray.pointAt(t);
@@ -36,13 +36,13 @@ HitRecord* Cylinder::intersect(const Ray& ray) const {
   float b = 2.0 * rex * rdx + 2.0 * rey * rdy;
   float c = rex * rex + rey * rey - 1;
 
-  float discriminant = b * b - 4 * a * c;
+  auto zeros = QuadraticSolver(a, b, c).solve();
 
-  if (discriminant < 0) {
+  if (zeros.size() < 2) {
     return new HitRecord();
   } else {
-    float t1 = (-b + sqrt(discriminant)) / (2.0 * a);
-    float t2 = (-b - sqrt(discriminant)) / (2.0 * a);
+    float t1 = zeros.at(0);
+    float t2 = zeros.at(1);
 
     float t = std::min(t1, t2);
     if (t < 0) {
@@ -66,16 +66,16 @@ std::vector<CsgSolid::IntervalBoundary> Cylinder::getIntervalBoundaries(const Ra
 
   float a = rdx * rdx + rdy * rdy;
   float b = 2.0 * rex * rdx + 2.0 * rey * rdy;
-  float c = rex * rex + rey * rey - 1;
+  float c = rex * rex + rey * rey - 1.0;
 
-  float discriminant = b * b - 4 * a * c;
+  auto zeros = QuadraticSolver(a, b, c).solve();
 
-  if (discriminant < 0) {
+  if (zeros.size() < 2) {
     return boundaries;
   }
 
-  float t1 = (-b + sqrt(discriminant)) / (2.0 * a);
-  float t2 = (-b - sqrt(discriminant)) / (2.0 * a);
+  float t1 = zeros.at(0);
+  float t2 = zeros.at(1);
 
   auto hit1 = buildHitRecord(t1, ray);
   IntervalBoundary b1;

--- a/src/intersectables/geometries/cylinder.cpp
+++ b/src/intersectables/geometries/cylinder.cpp
@@ -1,6 +1,6 @@
 #include "intersectables/geometries/cylinder.h"
-#include <iostream>
 #include <math/quadraticSolver.h>
+#include <iostream>
 
 HitRecord* Cylinder::buildHitRecord(float t, const Ray& ray) const {
   auto hitPosition = ray.pointAt(t);
@@ -23,7 +23,9 @@ HitRecord* Cylinder::buildHitRecord(float t, const Ray& ray) const {
   // clang-format on
 }
 
-Cylinder::Cylinder(Material* material) : material(material), aabb(computeAABB()) {}
+Cylinder::Cylinder(Material* material) : material(material), aabb(computeAABB()), radius(1.0) {}
+Cylinder::Cylinder(Material* material, float radius)
+    : material(material), aabb(computeAABB()), radius(radius) {}
 
 HitRecord* Cylinder::intersect(const Ray& ray) const {
   auto rdx = ray.direction->x;
@@ -34,7 +36,7 @@ HitRecord* Cylinder::intersect(const Ray& ray) const {
 
   float a = rdx * rdx + rdy * rdy;
   float b = 2.0 * rex * rdx + 2.0 * rey * rdy;
-  float c = rex * rex + rey * rey - 1;
+  float c = rex * rex + rey * rey - radius;
 
   auto zeros = QuadraticSolver(a, b, c).solve();
 

--- a/src/intersectables/geometries/plane.cpp
+++ b/src/intersectables/geometries/plane.cpp
@@ -72,16 +72,16 @@ std::vector<CsgSolid::IntervalBoundary> Plane::getIntervalBoundaries(const Ray& 
       b1.type = BoundaryType::START;
       b2.type = BoundaryType::END;
 
-      // If the t value of the START boundary was positive, so is
-      // the t value of the END boundary
+      // If the t value of the START boundary was positive, so is the t value
+      // of the END boundary
       b2.t = (hit->t > 0.0) ? std::numeric_limits<float>::max() : std::numeric_limits<float>::min();
 
     } else {
       b1.type = BoundaryType::END;
       b2.type = BoundaryType::START;
 
-      // If the t value of the END boundary was positive, then
-      // the t value of the START boundary is negative
+      // If the t value of the END boundary was positive, then the t value of
+      // the START boundary is negative
       b2.t = (hit->t > 0.0) ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max();
     }
 

--- a/src/intersectables/geometries/plane.cpp
+++ b/src/intersectables/geometries/plane.cpp
@@ -37,16 +37,18 @@ Plane::Plane(Material* material, const Vector3f& normal, float distance)
  * which is the definition of the intersection parameter t.
  *
  * However, we can further simplify the formula of t when assuming[1]
+ * and that p0 is defined as p0 := m * n, where m denotes a scalar.
  *
- * that p0 is defined as p0 = m * n, where m denotes a scalar.
  * This is useful when we want to define a plane by a distance value m and a
- * normal n
+ * normal n. By using this assumption, we can simplify the expression
  *
- * then dot(p0 - o, n) = dot(m*n - o, n)
- *                     = m * dot(n, n) - dot(o, n)
- *                     = m * 1 - dot(o, n)
- *                     = m - dot(o, n)
- * and hence
+ * dot(p0 - o, n) = dot(m*n - o, n)
+ *                = m * dot(n, n) - dot(o, n)
+ *                = m * 1 - dot(o, n)
+ *                = m - dot(o, n)
+ *
+ * and hence derive
+ *
  * t = (m - dot(o, n)) / dot(d, n)
  *
  *

--- a/src/intersectables/geometries/plane.cpp
+++ b/src/intersectables/geometries/plane.cpp
@@ -37,19 +37,23 @@ Plane::Plane(Material* material, const Vector3f& normal, float distance)
  * which is the definition of the intersection parameter t.
  *
  * However, we can further simplify the formula of t when assuming[1]
- * and that p0 is defined as p0 := m * n, where m denotes a scalar.
+ * and that p0 is defined as p0 := m * (0 - n), where m denotes a scalar and 0
+ * the origin of the work coordinate system. Notice that (0 - n) is the is a
+ * outwards pointing normal.
  *
  * This is useful when we want to define a plane by a distance value m and a
  * normal n. By using this assumption, we can simplify the expression
  *
- * dot(p0 - o, n) = dot(m*n - o, n)
- *                = m * dot(n, n) - dot(o, n)
- *                = m * 1 - dot(o, n)
- *                = m - dot(o, n)
+ * dot(p0 - o, n) = dot(m*(0 - n) - o, n)
+ *                = m * dot(-n, n) - dot(o, n)
+ *                = m * (-1) * dot(n, n) - dot(o, n)
+ *                = m * (-1) * (1) - dot(o, n)
+ *                = -m - dot(o, n)
+ *                = -(m + dot(o, n))
  *
  * and hence derive
  *
- * t = (m - dot(o, n)) / dot(d, n)
+ * t = -(m + dot(o, n)) / dot(d, n)
  *
  *
  * Remarks:
@@ -66,7 +70,7 @@ HitRecord* Plane::intersect(const Ray& ray) const {
   }
 
   // assumption: point is zero and then we shift by distance
-  float t = -(ray.origin->dot(normal) + distance) / cosTheta;
+  float t = -(distance + ray.origin->dot(normal)) / cosTheta;
   if (t <= 0) {
     return new HitRecord();
   }

--- a/src/intersectables/geometries/plane.cpp
+++ b/src/intersectables/geometries/plane.cpp
@@ -56,3 +56,38 @@ HitRecord* Plane::intersect(const Ray& ray) const {
   );
   // clang-format on
 }
+
+std::vector<CsgSolid::IntervalBoundary> Plane::getIntervalBoundaries(const Ray& ray) const {
+  std::vector<IntervalBoundary> boundaries;
+
+  IntervalBoundary b1, b2;
+  auto hit = intersect(ray);
+
+  if (hit->isValid()) {
+    b1.hitRecord = hit;
+    b1.t = hit->t;
+
+    // Determine if ray entered or left the half-space defined by the plane.
+    if (normal.dot(*ray.direction) < 0.0) {
+      b1.type = BoundaryType::START;
+      b2.type = BoundaryType::END;
+
+      // If the t value of the START boundary was positive, so is
+      // the t value of the END boundary
+      b2.t = (hit->t > 0.0) ? std::numeric_limits<float>::max() : std::numeric_limits<float>::min();
+
+    } else {
+      b1.type = BoundaryType::END;
+      b2.type = BoundaryType::START;
+
+      // If the t value of the END boundary was positive, then
+      // the t value of the START boundary is negative
+      b2.t = (hit->t > 0.0) ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max();
+    }
+
+    boundaries.push_back(b1);
+    boundaries.push_back(b2);
+  }
+
+  return boundaries;
+}

--- a/src/intersectables/geometries/plane.cpp
+++ b/src/intersectables/geometries/plane.cpp
@@ -16,7 +16,7 @@ Plane::Plane(Material* material, const Vector3f& normal, float distance)
  * This the implicit representation of a plane.
  *
  * A point on ray is given by the parametrization
- * r(t) = o + t*d [1] where
+ * r(t) = o + t*d where
  * o := (ox, oy, oz) denotes the origin of the ray and
  * d := (dx, dy, dz) denotes the direction of the ray and
  * t is float-valued parameter
@@ -36,7 +36,7 @@ Plane::Plane(Material* material, const Vector3f& normal, float distance)
  *
  * which is the definition of the intersection parameter t.
  *
- * However, we can further simplify the formula of t when assuming[1]
+ * However, we can further simplify the formula of t when assuming [1]
  * and that p0 is defined as p0 := m * (0 - n), where m denotes a scalar and 0
  * the origin of the work coordinate system. Notice that (0 - n) is the is a
  * outwards pointing normal.
@@ -54,7 +54,6 @@ Plane::Plane(Material* material, const Vector3f& normal, float distance)
  * and hence derive
  *
  * t = -(m + dot(o, n)) / dot(d, n)
- *
  *
  * Remarks:
  *

--- a/src/intersectables/geometries/plane.cpp
+++ b/src/intersectables/geometries/plane.cpp
@@ -5,12 +5,15 @@ Plane::Plane(Material* material, const Vector3f& normal, float distance)
     : material(material), normal(normal), distance(distance), aabb(initBoundingBox()) {}
 
 /**
- * The distance D between a point p and a plane can be computed by:
- * D := dot((p - a), n) [0]
- * where n is a unit normal on the plane, and a is a reference point on the
- * plane
+ * In the following a derivation of the intersection formula we are using in
+ * this implementation to compute the plane ray intersection:
  *
- * Notice: dot((p - a), n) = 0 gives us all points p on the plane
+ * A plane can be defined by a normal n and a point p0 on the plane.
+ * Then, every other point p on the plane fulfills
+ *
+ * dot(p - p0, n) = 0
+ *
+ * This the implicit representation of a plane.
  *
  * A point on ray is given by the parametrization
  * r(t) = o + t*d [1] where
@@ -18,10 +21,39 @@ Plane::Plane(Material* material, const Vector3f& normal, float distance)
  * d := (dx, dy, dz) denotes the direction of the ray and
  * t is float-valued parameter
  *
- * We can compute the distance between a point on the ray and the plane by
- * setting p = r(t), which gives us: D = dot(o + t*d - a)
- * t = dot(a - o, n) / dot(d, n) and a = (0, 0, D)
+ * By setting p = r(t) and using the plane definition, we get
  *
+ * dot(r(t) - p0, n) = dot(o + t*d - p0, n) = 0
+ *
+ * <=>
+ *
+ * dot(t*d, n) + dot(o - p0, n) = 0
+ *
+ * because dot(t*d, n) = t*dot(d, n)
+ * =>
+ * t = -dot(o - p0, n) / dot(d, n)
+ *   = dot(p0 - o, n) / dot(d, n)
+ *
+ * which is the definition of the intersection parameter t.
+ *
+ * However, we can further simplify the formula of t when assuming[1]
+ *
+ * that p0 is defined as p0 = m * n, where m denotes a scalar.
+ * This is useful when we want to define a plane by a distance value m and a
+ * normal n
+ *
+ * then dot(p0 - o, n) = dot(m*n - o, n)
+ *                     = m * dot(n, n) - dot(o, n)
+ *                     = m * 1 - dot(o, n)
+ *                     = m - dot(o, n)
+ * and hence
+ * t = (m - dot(o, n)) / dot(d, n)
+ *
+ *
+ * Remarks:
+ *
+ * [1] : This can only be performed, when assuming, that the normal is
+ * always pointing outwards, i.e. away from the origin)
  */
 HitRecord* Plane::intersect(const Ray& ray) const {
   // incident angle: angle between the ray direction and the plane normal
@@ -73,7 +105,8 @@ std::vector<CsgSolid::IntervalBoundary> Plane::getIntervalBoundaries(const Ray& 
 
       // If the t value of the START boundary was positive, so is the t value
       // of the END boundary
-      b2.t = (hit->t > 0.0) ? std::numeric_limits<float>::max() : -std::numeric_limits<float>::max();
+      b2.t =
+          (hit->t > 0.0) ? std::numeric_limits<float>::max() : -std::numeric_limits<float>::max();
 
     } else {
       b1.type = BoundaryType::END;
@@ -81,7 +114,8 @@ std::vector<CsgSolid::IntervalBoundary> Plane::getIntervalBoundaries(const Ray& 
 
       // If the t value of the END boundary was positive, then the t value of
       // the START boundary is negative
-      b2.t = (hit->t > 0.0) ? -std::numeric_limits<float>::max() : std::numeric_limits<float>::max();
+      b2.t =
+          (hit->t > 0.0) ? -std::numeric_limits<float>::max() : std::numeric_limits<float>::max();
     }
 
     boundaries.push_back(b1);

--- a/src/intersectables/geometries/plane.cpp
+++ b/src/intersectables/geometries/plane.cpp
@@ -39,7 +39,7 @@ Plane::Plane(Material* material, const Vector3f& normal, float distance)
  * However, we can further simplify the formula of t when assuming [1]
  * and that p0 is defined as p0 := m * (0 - n), where m denotes a scalar and 0
  * the origin of the work coordinate system. Notice that (0 - n) is the is a
- * outwards pointing normal.
+ * inwards pointing normal (the normal that points to the viewer)
  *
  * This is useful when we want to define a plane by a distance value m and a
  * normal n. By using this assumption, we can simplify the expression

--- a/src/intersectables/geometries/plane.cpp
+++ b/src/intersectables/geometries/plane.cpp
@@ -1,6 +1,5 @@
 #include "intersectables/geometries/plane.h"
 #include <cmath>
-#include <iostream>
 
 Plane::Plane(Material* material, const Vector3f& normal, float distance)
     : material(material), normal(normal), distance(distance), aabb(initBoundingBox()) {}
@@ -34,7 +33,7 @@ HitRecord* Plane::intersect(const Ray& ray) const {
 
   // assumption: point is zero and then we shift by distance
   float t = -(ray.origin->dot(normal) + distance) / cosTheta;
-  if (t < 0) {
+  if (t <= 0) {
     return new HitRecord();
   }
 
@@ -74,7 +73,7 @@ std::vector<CsgSolid::IntervalBoundary> Plane::getIntervalBoundaries(const Ray& 
 
       // If the t value of the START boundary was positive, so is the t value
       // of the END boundary
-      b2.t = (hit->t > 0.0) ? std::numeric_limits<float>::max() : std::numeric_limits<float>::min();
+      b2.t = (hit->t > 0.0) ? std::numeric_limits<float>::max() : -std::numeric_limits<float>::max();
 
     } else {
       b1.type = BoundaryType::END;
@@ -82,7 +81,7 @@ std::vector<CsgSolid::IntervalBoundary> Plane::getIntervalBoundaries(const Ray& 
 
       // If the t value of the END boundary was positive, then the t value of
       // the START boundary is negative
-      b2.t = (hit->t > 0.0) ? std::numeric_limits<float>::min() : std::numeric_limits<float>::max();
+      b2.t = (hit->t > 0.0) ? -std::numeric_limits<float>::max() : std::numeric_limits<float>::max();
     }
 
     boundaries.push_back(b1);

--- a/src/intersectables/geometries/sphere.cpp
+++ b/src/intersectables/geometries/sphere.cpp
@@ -105,7 +105,7 @@ HitRecord* Sphere::intersect(const Ray& ray) const {
 }
 
 std::vector<CsgSolid::IntervalBoundary> Sphere::getIntervalBoundaries(const Ray& ray) const {
-  std::vector<IntervalBoundary> boundaries(100);
+  std::vector<IntervalBoundary> boundaries;
 
   Vector3f oc(*ray.origin);
   oc.sub(center);

--- a/src/intersectables/geometries/sphere.cpp
+++ b/src/intersectables/geometries/sphere.cpp
@@ -1,6 +1,6 @@
 #include "intersectables/geometries/sphere.h"
-#include <cmath>
 #include <iostream>
+#include <math/quadraticSolver.h>
 
 HitRecord* Sphere::buildHitRecord(float t, const Ray& ray) const {
   auto hitPosition = ray.pointAt(t);
@@ -84,13 +84,14 @@ HitRecord* Sphere::intersect(const Ray& ray) const {
   float a = rd.dot();
   float b = 2.0 * rd.dot(oc);
   float c = oc.dot() - radius * radius;
-  float discriminant = b * b - 4 * a * c;
 
-  if (discriminant < 0) {
+  auto zeros = QuadraticSolver(a, b, c).solve();
+
+  if (zeros.size() < 2) {
     return new HitRecord();
   } else {
-    float t1 = (-b + sqrt(discriminant)) / (2.0 * a);
-    float t2 = (-b - sqrt(discriminant)) / (2.0 * a);
+    float t1 = zeros.at(0);
+    float t2 = zeros.at(1);
 
     float t = std::min(t1, t2);
     if (t < 0) {
@@ -114,14 +115,15 @@ std::vector<CsgSolid::IntervalBoundary> Sphere::getIntervalBoundaries(const Ray&
   float a = rd.dot();
   float b = 2.0 * rd.dot(oc);
   float c = oc.dot() - radius * radius;
-  float discriminant = b * b - 4 * a * c;
 
-  if (discriminant < 0) {
+  auto zeros = QuadraticSolver(a, b, c).solve();
+
+  if (zeros.size() < 2) {
     return boundaries;
   }
 
-  float t1 = (-b + sqrt(discriminant)) / (2.0 * a);
-  float t2 = (-b - sqrt(discriminant)) / (2.0 * a);
+  float t1 = zeros.at(0);
+  float t2 = zeros.at(1);
 
   auto hit1 = buildHitRecord(t1, ray);
   IntervalBoundary b1;

--- a/src/intersectables/geometries/sphere.cpp
+++ b/src/intersectables/geometries/sphere.cpp
@@ -22,7 +22,8 @@ HitRecord* Sphere::buildHitRecord(float t, const Ray& ray) const {
       ray.i,
       ray.j
     );
-	}
+  // clang-format on
+}
 
 Sphere::Sphere(Material* material, const Vector3f& center, float radius)
     : material(material), center(center), radius(radius), aabb(computeAABB(center, radius)) {}
@@ -127,7 +128,6 @@ std::vector<CsgSolid::IntervalBoundary> Sphere::getIntervalBoundaries(const Ray&
   b1.t = hit1->t;
   b1.type = findBoundaryType(hit1, ray);
   b1.hitRecord = hit1;
-
 
   auto hit2 = buildHitRecord(t2, ray);
   IntervalBoundary b2;

--- a/src/math/matrix4f.cpp
+++ b/src/math/matrix4f.cpp
@@ -80,6 +80,37 @@ Matrix4f::Matrix4f(const Vector4f& v1, const Vector4f& v2, const Vector4f& v3, c
   }
 }
 
+Matrix4f* Matrix4f::mult(const Matrix4f& other) {
+  auto r00 = m00 * other.m00 + m01 * other.m10 + m02 * other.m20 + m03 * other.m30;
+  auto r01 = m00 * other.m01 + m01 * other.m11 + m02 * other.m21 + m03 * other.m31;
+  auto r02 = m00 * other.m02 + m01 * other.m12 + m02 * other.m22 + m03 * other.m32;
+  auto r03 = m00 * other.m03 + m01 * other.m13 + m02 * other.m23 + m03 * other.m33;
+
+  auto r10 = m10 * other.m00 + m11 * other.m10 + m12 * other.m20 + m13 * other.m30;
+  auto r11 = m10 * other.m01 + m11 * other.m11 + m12 * other.m21 + m13 * other.m31;
+  auto r12 = m10 * other.m02 + m11 * other.m12 + m12 * other.m22 + m13 * other.m32;
+  auto r13 = m10 * other.m03 + m11 * other.m13 + m12 * other.m23 + m13 * other.m33;
+
+  auto r20 = m20 * other.m00 + m21 * other.m10 + m22 * other.m20 + m23 * other.m30;
+  auto r21 = m20 * other.m01 + m21 * other.m11 + m22 * other.m21 + m23 * other.m31;
+  auto r22 = m20 * other.m02 + m21 * other.m12 + m22 * other.m22 + m23 * other.m32;
+  auto r23 = m20 * other.m03 + m21 * other.m13 + m22 * other.m23 + m23 * other.m33;
+
+  auto r30 = m30 * other.m00 + m31 * other.m10 + m32 * other.m20 + m33 * other.m30;
+  auto r31 = m30 * other.m01 + m31 * other.m11 + m32 * other.m21 + m33 * other.m31;
+  auto r32 = m30 * other.m02 + m31 * other.m12 + m32 * other.m22 + m33 * other.m32;
+  auto r33 = m30 * other.m03 + m31 * other.m13 + m32 * other.m23 + m33 * other.m33;
+
+  // clang-format off
+  return new Matrix4f(
+    r00, r01, r02, r03,
+    r10, r11, r12, r13,
+    r20, r21, r22, r23,
+    r30, r31, r32, r33
+  );
+  // clang-format on
+}
+
 Vector4f* Matrix4f::mult(const Vector4f& other) {
   Vector4f v1(m00, m01, m02, m03);
   Vector4f v2(m10, m11, m12, m13);

--- a/src/math/quadraticSolver.cpp
+++ b/src/math/quadraticSolver.cpp
@@ -1,0 +1,22 @@
+#include "math/quadraticSolver.h"
+#include <cmath>
+
+QuadraticSolver::QuadraticSolver(const float a, const float b, const float c) : a(a), b(b), c(c) {}
+
+std::vector<float> QuadraticSolver::solve() {
+  std::vector<float> boundaries;
+
+  float discriminant = b * b - 4.0 * a * c;
+
+  if (discriminant < 0.0) {
+    return boundaries;
+  }
+
+  float t1 = (-b + sqrt(discriminant)) / (2.0 * a);
+  float t2 = (-b - sqrt(discriminant)) / (2.0 * a);
+
+  boundaries.push_back(t1);
+  boundaries.push_back(t2);
+
+  return boundaries;
+}

--- a/src/scenes/csgScene.cpp
+++ b/src/scenes/csgScene.cpp
@@ -1,0 +1,47 @@
+#include "scenes/csgScene.h"
+#include "integrators/debugIntegrator.h"
+#include "integrators/whittedIntegrator.h"
+#include "intersectables/geometries/plane.h"
+#include "intersectables/geometries/sphere.h"
+#include "materials/blinn.h"
+#include "materials/diffuse.h"
+
+CsgScene::CsgScene(int width, int height) : Scene(width, height) {}
+
+void CsgScene::buildCamera() {
+  Vector3f* eye = new Vector3f(0.0, 0.0, 3.0);
+  Vector3f* lookAt = new Vector3f(0.0, 0.0, 0.0);
+  Vector3f* up = new Vector3f(0.0, 1.0, 0.0);
+  float fov = 60.0;
+
+  float aspectRatio = (float)width / height;
+
+  Camera* camera = new Camera(eye, lookAt, up, fov, aspectRatio, width, height);
+  this->camera = camera;
+}
+
+void CsgScene::buildLights() {
+  std::vector<PointLight*>* lightList = new std::vector<PointLight*>;
+  lightList->push_back(new PointLight(Vector3f(0.5, 0.5, 2.0), new Spectrum(1.0)));
+  lightList->push_back(new PointLight(Vector3f(-0.75, 0.75, 2.0), new Spectrum(1.0, 0.0, 10.0)));
+  this->lightList = lightList;
+}
+
+void CsgScene::buildIntersectables() {
+  IntersectableList* intersectableList = new IntersectableList();
+  Blinn* material = new Blinn(new Spectrum(0.5, 0.5, 0.0), new Spectrum(0.6), 50.0);
+  Material* diffuse = new Diffuse(new Spectrum(0.0, 0.5, 0.5));
+  intersectableList->put(new Sphere(material, Vector3f(0.0, 0.0, 0.0), 0.5));
+  intersectableList->put(new Plane(diffuse, Vector3f(1.0, 0.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Vector3f(-1.0, 0.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Vector3f(0.0, 1.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Vector3f(0.0, -1.0, 0.0), 1));
+  intersectableList->put(new Plane(diffuse, Vector3f(0.0, 0.0, 1.0), 1));
+  this->intersectableList = intersectableList;
+}
+
+void CsgScene::buildIntegrator() {
+  // this->integrator = new DebugIntegrator(this);
+  this->integrator = new WhittedIntegrator(this->intersectableList, this->lightList);
+}
+

--- a/src/scenes/csgScene.cpp
+++ b/src/scenes/csgScene.cpp
@@ -6,6 +6,7 @@
 #include "intersectables/geometries/cube.h"
 #include "intersectables/geometries/plane.h"
 #include "intersectables/geometries/sphere.h"
+#include "intersectables/geometries/cylinder.h"
 #include "materials/blinn.h"
 #include "materials/diffuse.h"
 
@@ -53,6 +54,7 @@ void CsgScene::buildIntersectables() {
     0.0, 0.0, 0.0, 1.0
   );
   // clang-format on
+
   auto instance = new CsgInstance(node, transform);
   intersectableList->put(instance);
 

--- a/src/scenes/csgScene.cpp
+++ b/src/scenes/csgScene.cpp
@@ -3,7 +3,9 @@
 #include "integrators/whittedIntegrator.h"
 #include "intersectables/geometries/plane.h"
 #include "intersectables/geometries/sphere.h"
+#include "intersectables/geometries/cube.h"
 #include "intersectables/csg/csgNode.h"
+#include "intersectables/csg/csgInstance.h"
 #include "materials/blinn.h"
 #include "materials/diffuse.h"
 
@@ -35,9 +37,29 @@ void CsgScene::buildIntersectables() {
 
   auto s1 = new Sphere(material, Vector3f(0.0, -0.4, 0.0), 0.5);
   auto s2 = new Sphere(material, Vector3f(0.0, 0.4, 0.0), 0.5);
+  auto s3 = new Sphere(material, Vector3f(0.0, 0.0, 0.0), 0.25);
 
-  auto node = new CsgNode(s1, s2, SetOperation::INTERSECTION);
-  intersectableList->put(node);
+
+  auto n = new CsgNode(s1, s2, SetOperation::INTERSECTION);
+  auto node = new CsgNode(s3, n, SetOperation::INTERSECTION);
+
+  // clang-format off
+  Matrix4f* transform = new Matrix4f(
+    3.0, 0.0, 0.0, 0.0,
+    0.0, 3.0, 0.0, 0.0,
+    0.0, 0.0, 3.0, 0.0,
+    0.0, 0.0, 0.0, 1.0
+  );
+  // clang-format on
+
+  Instance* instance = new CsgInstance(node, transform);
+  intersectableList->put(instance);
+
+  // auto c1 = new Cube(material);
+  // auto c2 = new Cube(material);
+  // auto node2 = new CsgNode(s1, c2, SetOperation::INTERSECTION);
+  // intersectableList->put(node2);
+  // intersectableList->put(c1);
 
   intersectableList->put(new Plane(diffuse, Vector3f(1.0, 0.0, 0.0), 1));
   intersectableList->put(new Plane(diffuse, Vector3f(-1.0, 0.0, 0.0), 1));

--- a/src/scenes/csgScene.cpp
+++ b/src/scenes/csgScene.cpp
@@ -1,11 +1,11 @@
 #include "scenes/csgScene.h"
 #include "integrators/debugIntegrator.h"
 #include "integrators/whittedIntegrator.h"
+#include "intersectables/csg/csgInstance.h"
+#include "intersectables/csg/csgNode.h"
+#include "intersectables/geometries/cube.h"
 #include "intersectables/geometries/plane.h"
 #include "intersectables/geometries/sphere.h"
-#include "intersectables/geometries/cube.h"
-#include "intersectables/csg/csgNode.h"
-#include "intersectables/csg/csgInstance.h"
 #include "materials/blinn.h"
 #include "materials/diffuse.h"
 
@@ -25,8 +25,7 @@ void CsgScene::buildCamera() {
 
 void CsgScene::buildLights() {
   std::vector<PointLight*>* lightList = new std::vector<PointLight*>;
-  lightList->push_back(new PointLight(Vector3f(0.5, 0.5, 2.0), new Spectrum(1.0)));
-  lightList->push_back(new PointLight(Vector3f(-0.75, 0.75, 2.0), new Spectrum(1.0, 0.0, 10.0)));
+  lightList->push_back(new PointLight(Vector3f(0.5, 0, 2.0), new Spectrum(2)));
   this->lightList = lightList;
 }
 
@@ -39,27 +38,19 @@ void CsgScene::buildIntersectables() {
   auto s2 = new Sphere(material, Vector3f(0.0, 0.4, 0.0), 0.5);
   auto s3 = new Sphere(material, Vector3f(0.0, 0.0, 0.0), 0.25);
 
-
   auto n = new CsgNode(s1, s2, SetOperation::INTERSECTION);
   auto node = new CsgNode(s3, n, SetOperation::INTERSECTION);
 
   // clang-format off
   Matrix4f* transform = new Matrix4f(
-    3.0, 0.0, 0.0, 0.0,
-    0.0, 3.0, 0.0, 0.0,
-    0.0, 0.0, 3.0, 0.0,
+    2.5, 0.0, 0.0, 0.0,
+    0.0, 2.5, 0.0, 0.0,
+    0.0, 0.0, 2.5, 0.5,
     0.0, 0.0, 0.0, 1.0
   );
   // clang-format on
-
-  Instance* instance = new CsgInstance(node, transform);
+  auto instance = new CsgInstance(node, transform);
   intersectableList->put(instance);
-
-  // auto c1 = new Cube(material);
-  // auto c2 = new Cube(material);
-  // auto node2 = new CsgNode(s1, c2, SetOperation::INTERSECTION);
-  // intersectableList->put(node2);
-  // intersectableList->put(c1);
 
   intersectableList->put(new Plane(diffuse, Vector3f(1.0, 0.0, 0.0), 1));
   intersectableList->put(new Plane(diffuse, Vector3f(-1.0, 0.0, 0.0), 1));

--- a/src/scenes/csgScene.cpp
+++ b/src/scenes/csgScene.cpp
@@ -3,6 +3,7 @@
 #include "integrators/whittedIntegrator.h"
 #include "intersectables/geometries/plane.h"
 #include "intersectables/geometries/sphere.h"
+#include "intersectables/csg/csgNode.h"
 #include "materials/blinn.h"
 #include "materials/diffuse.h"
 
@@ -31,12 +32,19 @@ void CsgScene::buildIntersectables() {
   IntersectableList* intersectableList = new IntersectableList();
   Blinn* material = new Blinn(new Spectrum(0.5, 0.5, 0.0), new Spectrum(0.6), 50.0);
   Material* diffuse = new Diffuse(new Spectrum(0.0, 0.5, 0.5));
-  intersectableList->put(new Sphere(material, Vector3f(0.0, 0.0, 0.0), 0.5));
+
+  auto s1 = new Sphere(material, Vector3f(0.0, -0.4, 0.0), 0.5);
+  auto s2 = new Sphere(material, Vector3f(0.0, 0.4, 0.0), 0.5);
+
+  auto node = new CsgNode(s1, s2, SetOperation::INTERSECTION);
+  intersectableList->put(node);
+
   intersectableList->put(new Plane(diffuse, Vector3f(1.0, 0.0, 0.0), 1));
   intersectableList->put(new Plane(diffuse, Vector3f(-1.0, 0.0, 0.0), 1));
   intersectableList->put(new Plane(diffuse, Vector3f(0.0, 1.0, 0.0), 1));
   intersectableList->put(new Plane(diffuse, Vector3f(0.0, -1.0, 0.0), 1));
   intersectableList->put(new Plane(diffuse, Vector3f(0.0, 0.0, 1.0), 1));
+
   this->intersectableList = intersectableList;
 }
 

--- a/src/scenes/csgScene.cpp
+++ b/src/scenes/csgScene.cpp
@@ -12,8 +12,12 @@
 CsgScene::CsgScene(int width, int height) : Scene(width, height) {}
 
 void CsgScene::buildCamera() {
-  Vector3f* eye = new Vector3f(0.0, 0.0, 3.0);
+  Vector3f* eye = new Vector3f(0.0, 0.0, 2.5);
+
+  // positive x => bottom negative x => top
+  // positive y => right  negative y => left
   Vector3f* lookAt = new Vector3f(0.0, 0.0, 0.0);
+
   Vector3f* up = new Vector3f(0.0, 1.0, 0.0);
   float fov = 60.0;
 
@@ -52,11 +56,11 @@ void CsgScene::buildIntersectables() {
   auto instance = new CsgInstance(node, transform);
   intersectableList->put(instance);
 
-  intersectableList->put(new Plane(diffuse, Vector3f(1.0, 0.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, Vector3f(-1.0, 0.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, Vector3f(0.0, 1.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, Vector3f(0.0, -1.0, 0.0), 1));
-  intersectableList->put(new Plane(diffuse, Vector3f(0.0, 0.0, 1.0), 1));
+  intersectableList->put(new Plane(diffuse, Vector3f(1.0, 0.0, 0.0), 1));   // top
+  intersectableList->put(new Plane(diffuse, Vector3f(-1.0, 0.0, 0.0), 1));  // bottom
+  intersectableList->put(new Plane(diffuse, Vector3f(0.0, 1.0, 0.0), 1));   // left
+  intersectableList->put(new Plane(diffuse, Vector3f(0.0, -1.0, 0.0), 1));  // right
+  intersectableList->put(new Plane(diffuse, Vector3f(0.0, 0.0, 1.0), 1));   // back
 
   this->intersectableList = intersectableList;
 }

--- a/tests/math/matrix4f.cpp
+++ b/tests/math/matrix4f.cpp
@@ -42,6 +42,96 @@ TEST(Matrix4f, mult) {
   delete r;
 }
 
+TEST(Matrix4f, rotX) {
+  float v = 1.0 / sqrt(2.0);
+  float angle = 3.1415 / 4.0;
+  auto m = Matrix4f::rotX(angle);
+
+  float eps = 1e-4;
+  // computed via octave
+  ASSERT_NEAR(1.0, m->m00, eps);
+  ASSERT_NEAR(0.0, m->m01, eps);
+  ASSERT_NEAR(0.0, m->m02, eps);
+  ASSERT_NEAR(0, m->m03, eps);
+
+  ASSERT_NEAR(0., m->m10, eps);
+  ASSERT_NEAR(v, m->m11, eps);
+  ASSERT_NEAR(-v, m->m12, eps);
+  ASSERT_NEAR(0., m->m13, eps);
+
+  ASSERT_NEAR(0., m->m20, eps);
+  ASSERT_NEAR(v, m->m21, eps);
+  ASSERT_NEAR(v, m->m22, eps);
+  ASSERT_NEAR(0., m->m23, eps);
+
+  ASSERT_NEAR(0., m->m30, eps);
+  ASSERT_NEAR(0., m->m31, eps);
+  ASSERT_NEAR(0., m->m32, eps);
+  ASSERT_NEAR(1., m->m33, eps);
+
+  delete m;
+}
+
+TEST(Matrix4f, rotY) {
+  float v = 1.0 / sqrt(2.0);
+  float angle = 3.1415 / 4.0;
+  auto m = Matrix4f::rotY(angle);
+
+  float eps = 1e-4;
+  // computed via octave
+  ASSERT_NEAR(v, m->m00, eps);
+  ASSERT_NEAR(0.0, m->m01, eps);
+  ASSERT_NEAR(v, m->m02, eps);
+  ASSERT_NEAR(0, m->m03, eps);
+
+  ASSERT_NEAR(0., m->m10, eps);
+  ASSERT_NEAR(1, m->m11, eps);
+  ASSERT_NEAR(0, m->m12, eps);
+  ASSERT_NEAR(0., m->m13, eps);
+
+  ASSERT_NEAR(-v, m->m20, eps);
+  ASSERT_NEAR(0, m->m21, eps);
+  ASSERT_NEAR(v, m->m22, eps);
+  ASSERT_NEAR(0., m->m23, eps);
+
+  ASSERT_NEAR(0., m->m30, eps);
+  ASSERT_NEAR(0., m->m31, eps);
+  ASSERT_NEAR(0., m->m32, eps);
+  ASSERT_NEAR(1., m->m33, eps);
+
+  delete m;
+}
+
+TEST(Matrix4f, rotZ) {
+  float v = 1.0 / sqrt(2.0);
+  float angle = 3.1415 / 4.0;
+  auto m = Matrix4f::rotZ(angle);
+
+  float eps = 1e-4;
+  // computed via octave
+  ASSERT_NEAR(v, m->m00, eps);
+  ASSERT_NEAR(-v, m->m01, eps);
+  ASSERT_NEAR(0, m->m02, eps);
+  ASSERT_NEAR(0, m->m03, eps);
+
+  ASSERT_NEAR(v, m->m10, eps);
+  ASSERT_NEAR(v, m->m11, eps);
+  ASSERT_NEAR(0, m->m12, eps);
+  ASSERT_NEAR(0., m->m13, eps);
+
+  ASSERT_NEAR(0, m->m20, eps);
+  ASSERT_NEAR(0, m->m21, eps);
+  ASSERT_NEAR(1, m->m22, eps);
+  ASSERT_NEAR(0., m->m23, eps);
+
+  ASSERT_NEAR(0., m->m30, eps);
+  ASSERT_NEAR(0., m->m31, eps);
+  ASSERT_NEAR(0., m->m32, eps);
+  ASSERT_NEAR(1., m->m33, eps);
+
+  delete m;
+}
+
 TEST(Matrix4f, det) {
   Matrix4f mat(3, 2, -1, 4, 2, 1, 5, 7, 0, 5, 2, -6, -1, 2, 1, 0);
   ASSERT_EQ(-418, mat.det());
@@ -124,7 +214,7 @@ TEST(Matrix4f, transposed) {
 }
 
 TEST(Matrix4f, eye) {
-  auto m = Matrix4f().eye();
+  auto m = Matrix4f::eye();
 
   auto mat = m->transposed();
   ASSERT_EQ(1, mat->m00);

--- a/tests/math/matrix4f.cpp
+++ b/tests/math/matrix4f.cpp
@@ -42,6 +42,48 @@ TEST(Matrix4f, mult) {
   delete r;
 }
 
+TEST(Matrix4f, matrixMult) {
+  // clang-format off
+  Matrix4f A(
+    5, 2, 6, 1,
+    0, 6, 2, 0,
+    3, 8, 1, 4,
+    1, 8, 5, 6
+  );
+
+  Matrix4f B(
+    7, 5, 8, 0,
+    1, 8, 2, 6,
+    9, 4, 3, 8,
+    5, 3, 7, 9
+  );
+  // clang-format on
+
+  auto mat = A.mult(B);
+
+  ASSERT_EQ(96, mat->m00);
+  ASSERT_EQ(68, mat->m01);
+  ASSERT_EQ(69, mat->m02);
+  ASSERT_EQ(69, mat->m03);
+
+  ASSERT_EQ(24, mat->m10);
+  ASSERT_EQ(56, mat->m11);
+  ASSERT_EQ(18, mat->m12);
+  ASSERT_EQ(52, mat->m13);
+
+  ASSERT_EQ(58, mat->m20);
+  ASSERT_EQ(95, mat->m21);
+  ASSERT_EQ(71, mat->m22);
+  ASSERT_EQ(92, mat->m23);
+
+  ASSERT_EQ(90, mat->m30);
+  ASSERT_EQ(107, mat->m31);
+  ASSERT_EQ(81, mat->m32);
+  ASSERT_EQ(142, mat->m33);
+
+  delete mat;
+}
+
 TEST(Matrix4f, rotX) {
   float v = 1.0 / sqrt(2.0);
   float angle = 3.1415 / 4.0;

--- a/tests/renderer.cpp
+++ b/tests/renderer.cpp
@@ -7,6 +7,7 @@
 #include "refractiveScene.h"
 #include "renderer.h"
 #include "triangleTest.h"
+#include "csgScene.h"
 
 namespace {
 const int WIDTH = 40;
@@ -55,6 +56,22 @@ TEST(Renderer, RefractiveTest) {
 
 TEST(Renderer, MeshTest) {
   auto scene = new MeshTest(WIDTH, HEIGHT);
+  scene->setup();
+
+  Renderer renderer(scene, false);
+  renderer.render(1, SPP);
+}
+
+TEST(Renderer, TriangleTest) {
+  auto scene = new TriangleTest(WIDTH, HEIGHT);
+  scene->setup();
+
+  Renderer renderer(scene, false);
+  renderer.render(1, SPP);
+}
+
+TEST(Renderer, CsgScene) {
+  auto scene = new CsgScene(WIDTH, HEIGHT);
   scene->setup();
 
   Renderer renderer(scene, false);


### PR DESCRIPTION
See https://trello.com/c/vDNQLLi0

## TODOs

+ [x] Refactor existing geometry classes to extend the `CsgSolid` class (instead of `Intersectable`) - this only addresses solid promitives (such as spheres, cones, cylinders, cubes).
+ [x] Implement Cube
+ [x] Implement quadratic solver.